### PR TITLE
Add JSON channel handling alongside stream support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - **🎯 Advanced Triggers**: Rich trigger system with throttling, debouncing, delays, and conditions
 - **🔧 Framework Agnostic**: Works with Express, Hono, and other frameworks via adapters
 - **🌐 Broadcasting**: Send updates to all connected clients or specific connections
+- **🎧 Binary Streams**: Pipe audio or any binary payloads between browser and server with minimal setup
 - **⚡ Swap Modifiers**: Control timing, positioning, and animation of DOM updates
 - **🔌 Easy Integration**: Drop-in client library with minimal configuration
 - **📦 Monorepo Structure**: Organized packages for core, adapters, and client
@@ -307,6 +308,112 @@ wsx.on((request, connection) => {
   console.log(`Request from ${connection.id}: ${request.handler}`);
 });
 ```
+
+## 🎧 Streaming Binary Data
+
+WSX can transport arbitrary binary payloads alongside traditional HTML updates. This enables scenarios such as piping audio from
+the browser to the server (and back) without leaving the WSX programming model.
+
+### Server-side streaming
+
+```javascript
+// Receive audio chunks and relay them to all connected clients
+wsx.onStream("audio", async (message, data, connection) => {
+  console.log(
+    `Received audio chunk ${message.id} from ${connection.id} (${data.byteLength} bytes)`
+  );
+
+  // Forward the raw bytes back out to listeners, preserving metadata
+  wsx.broadcastStream("audio", data, { metadata: message.metadata });
+});
+
+// Target a single connection when needed
+// wsx.sendStreamToConnection(connectionId, "audio", data, { metadata: { mimeType: "audio/webm" } });
+```
+
+The `onStream` handler receives a metadata object (`id`, `channel`, and optional `metadata`) together with the raw `Uint8Array`
+payload. The new `broadcastStream` and `sendStreamToConnection` helpers mirror the HTML response helpers, but operate on binary
+buffers instead.
+
+### Client-side streaming
+
+```javascript
+// Listen for incoming audio and play it back
+wsx.onStream("audio", ({ data, metadata }) => {
+  const mimeType = metadata?.mimeType || "audio/webm";
+  const buffer = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
+  const audioBlob = new Blob([buffer], { type: mimeType });
+  const url = URL.createObjectURL(audioBlob);
+  const audio = new Audio(url);
+  audio.play();
+});
+
+// Capture microphone input and push it to the server
+const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+const recorder = new MediaRecorder(stream, { mimeType: "audio/webm" });
+
+recorder.ondataavailable = async (event) => {
+  if (event.data.size > 0) {
+    await wsx.sendStream("audio", event.data, {
+      metadata: { mimeType: event.data.type, sampleRate: 48000 },
+    });
+  }
+};
+
+recorder.start(250); // send audio in 250ms chunks
+```
+
+`sendStream` accepts `ArrayBuffer`, typed arrays, or `Blob` instances, making it simple to forward chunks produced by the
+`MediaRecorder` API or other binary sources. Stream handlers can also be registered without a channel name to observe every
+incoming stream: `wsx.onStream((stream) => console.log(stream.channel));`.
+
+## 🔁 JSON Channels
+
+In addition to HTML responses and binary streams, WSX can move arbitrary JSON documents in either direction. JSON channels behave
+similarly to streams: register handlers on both server and client, then send messages to a named channel whenever you have
+structured data to share.
+
+### Server-side JSON handlers
+
+```ts
+wsx.onJson("presence", async (message, connection) => {
+  console.log(
+    `Presence update from ${connection.id}: ${message.data.status}`
+  );
+
+  // Broadcast the update to everyone, echoing metadata if provided
+  wsx.broadcastJson("presence", {
+    userId: connection.id,
+    status: message.data.status,
+  });
+});
+
+// Target a specific connection with metadata when needed
+// wsx.sendJsonToConnection(connectionId, "presence", { status: "away" }, {
+//   metadata: { expiresAt: Date.now() + 30000 },
+// });
+```
+
+### Client-side JSON channels
+
+```js
+// Listen for presence updates
+wsx.onJson("presence", ({ data, metadata }) => {
+  console.log("Presence change", data, metadata);
+});
+
+// Push a JSON payload to the server
+wsx.sendJson("presence", { status: "online" }, {
+  metadata: { since: Date.now() },
+});
+
+// Observe every JSON message with a catch-all handler
+// wsx.onJson((message) => console.log(message.channel, message.data));
+```
+
+Every JSON payload receives a unique identifier which is returned from `sendJson`, `broadcastJson`, and `sendJsonToConnection`.
+Metadata travels with the payload in both directions so you can attach contextual information without altering the core data
+shape.
 
 ## 📚 Examples
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,48 +6,49 @@
       "devDependencies": {
         "@types/node": "^20.0.0",
         "tsup": "^8.0.0",
-        "typescript": "^5.0.0"
-      }
+        "typescript": "^5.0.0",
+      },
     },
     "examples/express": {
       "name": "wsx-express-example",
       "dependencies": {
         "@wsx-sh/express": "workspace:*",
         "express": "^4.18.0",
-        "ws": "^8.0.0"
+        "ws": "^8.0.0",
       },
       "devDependencies": {
         "@types/express": "^4.17.0",
-        "@types/ws": "^8.0.0"
-      }
+        "@types/ws": "^8.0.0",
+      },
     },
     "examples/hono": {
       "name": "wsx-hono-example",
       "dependencies": {
+        "@wsx-sh/core": "workspace:*",
         "@wsx-sh/hono": "workspace:*",
-        "hono": "^4.8.4"
+        "hono": "^4.8.4",
       },
       "devDependencies": {
-        "wrangler": "^4.4.0"
-      }
+        "wrangler": "^4.4.0",
+      },
     },
     "packages/client": {
-      "name": "@wsx-sh/client",
-      "version": "1.0.0"
+      "name": "@stukennedy/wsx-client",
+      "version": "1.0.1",
     },
     "packages/core": {
       "name": "@wsx-sh/core",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "devDependencies": {
         "tsup": "^8.0.0",
-        "typescript": "^5.0.0"
-      }
+        "typescript": "^5.0.0",
+      },
     },
     "packages/express": {
       "name": "@wsx-sh/express",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
-        "@wsx-sh/core": "workspace:*"
+        "@wsx-sh/core": "workspace:*",
       },
       "devDependencies": {
         "@types/express": "^4.17.0",
@@ -56,802 +57,227 @@
         "express": "^4.18.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
-        "ws": "^8.0.0"
+        "ws": "^8.0.0",
       },
       "peerDependencies": {
         "express": ">=4.0.0",
-        "ws": ">=8.0.0"
-      }
+        "ws": ">=8.0.0",
+      },
     },
     "packages/hono": {
       "name": "@wsx-sh/hono",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
-        "@wsx-sh/core": "workspace:*"
+        "@wsx-sh/core": "workspace:*",
       },
       "devDependencies": {
         "hono": "^4.8.4",
         "tsup": "^8.0.0",
-        "typescript": "^5.0.0"
+        "typescript": "^5.0.0",
       },
       "peerDependencies": {
-        "hono": ">=4.0.0"
-      }
-    }
+        "hono": ">=4.0.0",
+      },
+    },
   },
   "packages": {
-    "@cloudflare/kv-asset-handler": [
-      "@cloudflare/kv-asset-handler@0.4.0",
-      "",
-      { "dependencies": { "mime": "^3.0.0" } },
-      "sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA=="
-    ],
-
-    "@cloudflare/unenv-preset": [
-      "@cloudflare/unenv-preset@2.3.3",
-      "",
-      {
-        "peerDependencies": {
-          "unenv": "2.0.0-rc.17",
-          "workerd": "^1.20250508.0"
-        },
-        "optionalPeers": ["workerd"]
-      },
-      "sha512-/M3MEcj3V2WHIRSW1eAQBPRJ6JnGQHc6JKMAPLkDb7pLs3m6X9ES/+K3ceGqxI6TKeF32AWAi7ls0AYzVxCP0A=="
-    ],
-
-    "@cloudflare/workerd-darwin-64": [
-      "@cloudflare/workerd-darwin-64@1.20250709.0",
-      "",
-      { "os": "darwin", "cpu": "x64" },
-      "sha512-VqwcvnbI8FNCP87ZWNHA3/sAC5U9wMbNnjBG0sHEYzM7B9RPHKYHdVKdBEWhzZXnkQYMK81IHm4CZsK16XxAuQ=="
-    ],
-
-    "@cloudflare/workerd-darwin-arm64": [
-      "@cloudflare/workerd-darwin-arm64@1.20250709.0",
-      "",
-      { "os": "darwin", "cpu": "arm64" },
-      "sha512-A54ttSgXMM4huChPTThhkieOjpDxR+srVOO9zjTHVIyoQxA8zVsku4CcY/GQ95RczMV+yCKVVu/tAME7vwBFuA=="
-    ],
-
-    "@cloudflare/workerd-linux-64": [
-      "@cloudflare/workerd-linux-64@1.20250709.0",
-      "",
-      { "os": "linux", "cpu": "x64" },
-      "sha512-no4O3OK+VXINIxv99OHJDpIgML2ZssrSvImwLtULzqm+cl4t1PIfXNRUqj89ujTkmad+L9y4G6dBQMPCLnmlGg=="
-    ],
-
-    "@cloudflare/workerd-linux-arm64": [
-      "@cloudflare/workerd-linux-arm64@1.20250709.0",
-      "",
-      { "os": "linux", "cpu": "arm64" },
-      "sha512-7cNICk2Qd+m4QGrcmWyAuZJXTHt1ud6isA+dic7Yk42WZmwXhlcUATyvFD9FSQNFcldjuRB4n8JlWEFqZBn+lw=="
-    ],
-
-    "@cloudflare/workerd-windows-64": [
-      "@cloudflare/workerd-windows-64@1.20250709.0",
-      "",
-      { "os": "win32", "cpu": "x64" },
-      "sha512-j1AyO8V/62Q23EJplWgzBlRCqo/diXgox58AbDqSqgyzCBAlvUzXQRDBab/FPNG/erRqt7I1zQhahrBhrM0uLA=="
-    ],
-
-    "@cspotcode/source-map-support": [
-      "@cspotcode/source-map-support@0.8.1",
-      "",
-      { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } },
-      "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="
-    ],
-
-    "@emnapi/runtime": [
-      "@emnapi/runtime@1.4.4",
-      "",
-      { "dependencies": { "tslib": "^2.4.0" } },
-      "sha512-hHyapA4A3gPaDCNfiqyZUStTMqIkKRshqPIuDOXv1hcBnD4U3l8cP0T1HMCfGRxQ6V64TGCcoswChANyOAwbQg=="
-    ],
-
-    "@esbuild/aix-ppc64": [
-      "@esbuild/aix-ppc64@0.25.4",
-      "",
-      { "os": "aix", "cpu": "ppc64" },
-      "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q=="
-    ],
-
-    "@esbuild/android-arm": [
-      "@esbuild/android-arm@0.25.4",
-      "",
-      { "os": "android", "cpu": "arm" },
-      "sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ=="
-    ],
-
-    "@esbuild/android-arm64": [
-      "@esbuild/android-arm64@0.25.4",
-      "",
-      { "os": "android", "cpu": "arm64" },
-      "sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A=="
-    ],
-
-    "@esbuild/android-x64": [
-      "@esbuild/android-x64@0.25.4",
-      "",
-      { "os": "android", "cpu": "x64" },
-      "sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ=="
-    ],
-
-    "@esbuild/darwin-arm64": [
-      "@esbuild/darwin-arm64@0.25.4",
-      "",
-      { "os": "darwin", "cpu": "arm64" },
-      "sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g=="
-    ],
-
-    "@esbuild/darwin-x64": [
-      "@esbuild/darwin-x64@0.25.4",
-      "",
-      { "os": "darwin", "cpu": "x64" },
-      "sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A=="
-    ],
-
-    "@esbuild/freebsd-arm64": [
-      "@esbuild/freebsd-arm64@0.25.4",
-      "",
-      { "os": "freebsd", "cpu": "arm64" },
-      "sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ=="
-    ],
-
-    "@esbuild/freebsd-x64": [
-      "@esbuild/freebsd-x64@0.25.4",
-      "",
-      { "os": "freebsd", "cpu": "x64" },
-      "sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ=="
-    ],
-
-    "@esbuild/linux-arm": [
-      "@esbuild/linux-arm@0.25.4",
-      "",
-      { "os": "linux", "cpu": "arm" },
-      "sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ=="
-    ],
-
-    "@esbuild/linux-arm64": [
-      "@esbuild/linux-arm64@0.25.4",
-      "",
-      { "os": "linux", "cpu": "arm64" },
-      "sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ=="
-    ],
-
-    "@esbuild/linux-ia32": [
-      "@esbuild/linux-ia32@0.25.4",
-      "",
-      { "os": "linux", "cpu": "ia32" },
-      "sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ=="
-    ],
-
-    "@esbuild/linux-loong64": [
-      "@esbuild/linux-loong64@0.25.4",
-      "",
-      { "os": "linux", "cpu": "none" },
-      "sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA=="
-    ],
-
-    "@esbuild/linux-mips64el": [
-      "@esbuild/linux-mips64el@0.25.4",
-      "",
-      { "os": "linux", "cpu": "none" },
-      "sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg=="
-    ],
-
-    "@esbuild/linux-ppc64": [
-      "@esbuild/linux-ppc64@0.25.4",
-      "",
-      { "os": "linux", "cpu": "ppc64" },
-      "sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag=="
-    ],
-
-    "@esbuild/linux-riscv64": [
-      "@esbuild/linux-riscv64@0.25.4",
-      "",
-      { "os": "linux", "cpu": "none" },
-      "sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA=="
-    ],
-
-    "@esbuild/linux-s390x": [
-      "@esbuild/linux-s390x@0.25.4",
-      "",
-      { "os": "linux", "cpu": "s390x" },
-      "sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g=="
-    ],
-
-    "@esbuild/linux-x64": [
-      "@esbuild/linux-x64@0.25.4",
-      "",
-      { "os": "linux", "cpu": "x64" },
-      "sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA=="
-    ],
-
-    "@esbuild/netbsd-arm64": [
-      "@esbuild/netbsd-arm64@0.25.4",
-      "",
-      { "os": "none", "cpu": "arm64" },
-      "sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ=="
-    ],
-
-    "@esbuild/netbsd-x64": [
-      "@esbuild/netbsd-x64@0.25.4",
-      "",
-      { "os": "none", "cpu": "x64" },
-      "sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw=="
-    ],
-
-    "@esbuild/openbsd-arm64": [
-      "@esbuild/openbsd-arm64@0.25.4",
-      "",
-      { "os": "openbsd", "cpu": "arm64" },
-      "sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A=="
-    ],
-
-    "@esbuild/openbsd-x64": [
-      "@esbuild/openbsd-x64@0.25.4",
-      "",
-      { "os": "openbsd", "cpu": "x64" },
-      "sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw=="
-    ],
-
-    "@esbuild/sunos-x64": [
-      "@esbuild/sunos-x64@0.25.4",
-      "",
-      { "os": "sunos", "cpu": "x64" },
-      "sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q=="
-    ],
-
-    "@esbuild/win32-arm64": [
-      "@esbuild/win32-arm64@0.25.4",
-      "",
-      { "os": "win32", "cpu": "arm64" },
-      "sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ=="
-    ],
-
-    "@esbuild/win32-ia32": [
-      "@esbuild/win32-ia32@0.25.4",
-      "",
-      { "os": "win32", "cpu": "ia32" },
-      "sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg=="
-    ],
-
-    "@esbuild/win32-x64": [
-      "@esbuild/win32-x64@0.25.4",
-      "",
-      { "os": "win32", "cpu": "x64" },
-      "sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ=="
-    ],
-
-    "@fastify/busboy": [
-      "@fastify/busboy@2.1.1",
-      "",
-      {},
-      "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
-    ],
-
-    "@img/sharp-darwin-arm64": [
-      "@img/sharp-darwin-arm64@0.33.5",
-      "",
-      {
-        "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.0.4" },
-        "os": "darwin",
-        "cpu": "arm64"
-      },
-      "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ=="
-    ],
-
-    "@img/sharp-darwin-x64": [
-      "@img/sharp-darwin-x64@0.33.5",
-      "",
-      {
-        "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.0.4" },
-        "os": "darwin",
-        "cpu": "x64"
-      },
-      "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q=="
-    ],
-
-    "@img/sharp-libvips-darwin-arm64": [
-      "@img/sharp-libvips-darwin-arm64@1.0.4",
-      "",
-      { "os": "darwin", "cpu": "arm64" },
-      "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg=="
-    ],
-
-    "@img/sharp-libvips-darwin-x64": [
-      "@img/sharp-libvips-darwin-x64@1.0.4",
-      "",
-      { "os": "darwin", "cpu": "x64" },
-      "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ=="
-    ],
-
-    "@img/sharp-libvips-linux-arm": [
-      "@img/sharp-libvips-linux-arm@1.0.5",
-      "",
-      { "os": "linux", "cpu": "arm" },
-      "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g=="
-    ],
-
-    "@img/sharp-libvips-linux-arm64": [
-      "@img/sharp-libvips-linux-arm64@1.0.4",
-      "",
-      { "os": "linux", "cpu": "arm64" },
-      "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA=="
-    ],
-
-    "@img/sharp-libvips-linux-s390x": [
-      "@img/sharp-libvips-linux-s390x@1.0.4",
-      "",
-      { "os": "linux", "cpu": "s390x" },
-      "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA=="
-    ],
-
-    "@img/sharp-libvips-linux-x64": [
-      "@img/sharp-libvips-linux-x64@1.0.4",
-      "",
-      { "os": "linux", "cpu": "x64" },
-      "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw=="
-    ],
-
-    "@img/sharp-libvips-linuxmusl-arm64": [
-      "@img/sharp-libvips-linuxmusl-arm64@1.0.4",
-      "",
-      { "os": "linux", "cpu": "arm64" },
-      "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA=="
-    ],
-
-    "@img/sharp-libvips-linuxmusl-x64": [
-      "@img/sharp-libvips-linuxmusl-x64@1.0.4",
-      "",
-      { "os": "linux", "cpu": "x64" },
-      "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw=="
-    ],
-
-    "@img/sharp-linux-arm": [
-      "@img/sharp-linux-arm@0.33.5",
-      "",
-      {
-        "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.0.5" },
-        "os": "linux",
-        "cpu": "arm"
-      },
-      "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ=="
-    ],
-
-    "@img/sharp-linux-arm64": [
-      "@img/sharp-linux-arm64@0.33.5",
-      "",
-      {
-        "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.0.4" },
-        "os": "linux",
-        "cpu": "arm64"
-      },
-      "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA=="
-    ],
-
-    "@img/sharp-linux-s390x": [
-      "@img/sharp-linux-s390x@0.33.5",
-      "",
-      {
-        "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.0.4" },
-        "os": "linux",
-        "cpu": "s390x"
-      },
-      "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q=="
-    ],
-
-    "@img/sharp-linux-x64": [
-      "@img/sharp-linux-x64@0.33.5",
-      "",
-      {
-        "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.0.4" },
-        "os": "linux",
-        "cpu": "x64"
-      },
-      "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA=="
-    ],
-
-    "@img/sharp-linuxmusl-arm64": [
-      "@img/sharp-linuxmusl-arm64@0.33.5",
-      "",
-      {
-        "optionalDependencies": {
-          "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
-        },
-        "os": "linux",
-        "cpu": "arm64"
-      },
-      "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g=="
-    ],
-
-    "@img/sharp-linuxmusl-x64": [
-      "@img/sharp-linuxmusl-x64@0.33.5",
-      "",
-      {
-        "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.0.4" },
-        "os": "linux",
-        "cpu": "x64"
-      },
-      "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw=="
-    ],
-
-    "@img/sharp-wasm32": [
-      "@img/sharp-wasm32@0.33.5",
-      "",
-      { "dependencies": { "@emnapi/runtime": "^1.2.0" }, "cpu": "none" },
-      "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg=="
-    ],
-
-    "@img/sharp-win32-ia32": [
-      "@img/sharp-win32-ia32@0.33.5",
-      "",
-      { "os": "win32", "cpu": "ia32" },
-      "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ=="
-    ],
-
-    "@img/sharp-win32-x64": [
-      "@img/sharp-win32-x64@0.33.5",
-      "",
-      { "os": "win32", "cpu": "x64" },
-      "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg=="
-    ],
-
-    "@isaacs/cliui": [
-      "@isaacs/cliui@8.0.2",
-      "",
-      {
-        "dependencies": {
-          "string-width": "^5.1.2",
-          "string-width-cjs": "npm:string-width@^4.2.0",
-          "strip-ansi": "^7.0.1",
-          "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-          "wrap-ansi": "^8.1.0",
-          "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-        }
-      },
-      "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="
-    ],
-
-    "@jridgewell/gen-mapping": [
-      "@jridgewell/gen-mapping@0.3.12",
-      "",
-      {
-        "dependencies": {
-          "@jridgewell/sourcemap-codec": "^1.5.0",
-          "@jridgewell/trace-mapping": "^0.3.24"
-        }
-      },
-      "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg=="
-    ],
-
-    "@jridgewell/resolve-uri": [
-      "@jridgewell/resolve-uri@3.1.2",
-      "",
-      {},
-      "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="
-    ],
-
-    "@jridgewell/sourcemap-codec": [
-      "@jridgewell/sourcemap-codec@1.5.4",
-      "",
-      {},
-      "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw=="
-    ],
-
-    "@jridgewell/trace-mapping": [
-      "@jridgewell/trace-mapping@0.3.29",
-      "",
-      {
-        "dependencies": {
-          "@jridgewell/resolve-uri": "^3.1.0",
-          "@jridgewell/sourcemap-codec": "^1.4.14"
-        }
-      },
-      "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ=="
-    ],
-
-    "@pkgjs/parseargs": [
-      "@pkgjs/parseargs@0.11.0",
-      "",
-      {},
-      "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="
-    ],
-
-    "@poppinss/colors": [
-      "@poppinss/colors@4.1.5",
-      "",
-      { "dependencies": { "kleur": "^4.1.5" } },
-      "sha512-FvdDqtcRCtz6hThExcFOgW0cWX+xwSMWcRuQe5ZEb2m7cVQOAVZOIMt+/v9RxGiD9/OY16qJBXK4CVKWAPalBw=="
-    ],
-
-    "@poppinss/dumper": [
-      "@poppinss/dumper@0.6.4",
-      "",
-      {
-        "dependencies": {
-          "@poppinss/colors": "^4.1.5",
-          "@sindresorhus/is": "^7.0.2",
-          "supports-color": "^10.0.0"
-        }
-      },
-      "sha512-iG0TIdqv8xJ3Lt9O8DrPRxw1MRLjNpoqiSGU03P/wNLP/s0ra0udPJ1J2Tx5M0J3H/cVyEgpbn8xUKRY9j59kQ=="
-    ],
-
-    "@poppinss/exception": [
-      "@poppinss/exception@1.2.2",
-      "",
-      {},
-      "sha512-m7bpKCD4QMlFCjA/nKTs23fuvoVFoA83brRKmObCUNmi/9tVu8Ve3w4YQAnJu4q3Tjf5fr685HYIC/IA2zHRSg=="
-    ],
-
-    "@rollup/rollup-android-arm-eabi": [
-      "@rollup/rollup-android-arm-eabi@4.45.0",
-      "",
-      { "os": "android", "cpu": "arm" },
-      "sha512-2o/FgACbji4tW1dzXOqAV15Eu7DdgbKsF2QKcxfG4xbh5iwU7yr5RRP5/U+0asQliSYv5M4o7BevlGIoSL0LXg=="
-    ],
-
-    "@rollup/rollup-android-arm64": [
-      "@rollup/rollup-android-arm64@4.45.0",
-      "",
-      { "os": "android", "cpu": "arm64" },
-      "sha512-PSZ0SvMOjEAxwZeTx32eI/j5xSYtDCRxGu5k9zvzoY77xUNssZM+WV6HYBLROpY5CkXsbQjvz40fBb7WPwDqtQ=="
-    ],
-
-    "@rollup/rollup-darwin-arm64": [
-      "@rollup/rollup-darwin-arm64@4.45.0",
-      "",
-      { "os": "darwin", "cpu": "arm64" },
-      "sha512-BA4yPIPssPB2aRAWzmqzQ3y2/KotkLyZukVB7j3psK/U3nVJdceo6qr9pLM2xN6iRP/wKfxEbOb1yrlZH6sYZg=="
-    ],
-
-    "@rollup/rollup-darwin-x64": [
-      "@rollup/rollup-darwin-x64@4.45.0",
-      "",
-      { "os": "darwin", "cpu": "x64" },
-      "sha512-Pr2o0lvTwsiG4HCr43Zy9xXrHspyMvsvEw4FwKYqhli4FuLE5FjcZzuQ4cfPe0iUFCvSQG6lACI0xj74FDZKRA=="
-    ],
-
-    "@rollup/rollup-freebsd-arm64": [
-      "@rollup/rollup-freebsd-arm64@4.45.0",
-      "",
-      { "os": "freebsd", "cpu": "arm64" },
-      "sha512-lYE8LkE5h4a/+6VnnLiL14zWMPnx6wNbDG23GcYFpRW1V9hYWHAw9lBZ6ZUIrOaoK7NliF1sdwYGiVmziUF4vA=="
-    ],
-
-    "@rollup/rollup-freebsd-x64": [
-      "@rollup/rollup-freebsd-x64@4.45.0",
-      "",
-      { "os": "freebsd", "cpu": "x64" },
-      "sha512-PVQWZK9sbzpvqC9Q0GlehNNSVHR+4m7+wET+7FgSnKG3ci5nAMgGmr9mGBXzAuE5SvguCKJ6mHL6vq1JaJ/gvw=="
-    ],
-
-    "@rollup/rollup-linux-arm-gnueabihf": [
-      "@rollup/rollup-linux-arm-gnueabihf@4.45.0",
-      "",
-      { "os": "linux", "cpu": "arm" },
-      "sha512-hLrmRl53prCcD+YXTfNvXd776HTxNh8wPAMllusQ+amcQmtgo3V5i/nkhPN6FakW+QVLoUUr2AsbtIRPFU3xIA=="
-    ],
-
-    "@rollup/rollup-linux-arm-musleabihf": [
-      "@rollup/rollup-linux-arm-musleabihf@4.45.0",
-      "",
-      { "os": "linux", "cpu": "arm" },
-      "sha512-XBKGSYcrkdiRRjl+8XvrUR3AosXU0NvF7VuqMsm7s5nRy+nt58ZMB19Jdp1RdqewLcaYnpk8zeVs/4MlLZEJxw=="
-    ],
-
-    "@rollup/rollup-linux-arm64-gnu": [
-      "@rollup/rollup-linux-arm64-gnu@4.45.0",
-      "",
-      { "os": "linux", "cpu": "arm64" },
-      "sha512-fRvZZPUiBz7NztBE/2QnCS5AtqLVhXmUOPj9IHlfGEXkapgImf4W9+FSkL8cWqoAjozyUzqFmSc4zh2ooaeF6g=="
-    ],
-
-    "@rollup/rollup-linux-arm64-musl": [
-      "@rollup/rollup-linux-arm64-musl@4.45.0",
-      "",
-      { "os": "linux", "cpu": "arm64" },
-      "sha512-Btv2WRZOcUGi8XU80XwIvzTg4U6+l6D0V6sZTrZx214nrwxw5nAi8hysaXj/mctyClWgesyuxbeLylCBNauimg=="
-    ],
-
-    "@rollup/rollup-linux-loongarch64-gnu": [
-      "@rollup/rollup-linux-loongarch64-gnu@4.45.0",
-      "",
-      { "os": "linux", "cpu": "none" },
-      "sha512-Li0emNnwtUZdLwHjQPBxn4VWztcrw/h7mgLyHiEI5Z0MhpeFGlzaiBHpSNVOMB/xucjXTTcO+dhv469Djr16KA=="
-    ],
-
-    "@rollup/rollup-linux-powerpc64le-gnu": [
-      "@rollup/rollup-linux-powerpc64le-gnu@4.45.0",
-      "",
-      { "os": "linux", "cpu": "ppc64" },
-      "sha512-sB8+pfkYx2kvpDCfd63d5ScYT0Fz1LO6jIb2zLZvmK9ob2D8DeVqrmBDE0iDK8KlBVmsTNzrjr3G1xV4eUZhSw=="
-    ],
-
-    "@rollup/rollup-linux-riscv64-gnu": [
-      "@rollup/rollup-linux-riscv64-gnu@4.45.0",
-      "",
-      { "os": "linux", "cpu": "none" },
-      "sha512-5GQ6PFhh7E6jQm70p1aW05G2cap5zMOvO0se5JMecHeAdj5ZhWEHbJ4hiKpfi1nnnEdTauDXxPgXae/mqjow9w=="
-    ],
-
-    "@rollup/rollup-linux-riscv64-musl": [
-      "@rollup/rollup-linux-riscv64-musl@4.45.0",
-      "",
-      { "os": "linux", "cpu": "none" },
-      "sha512-N/euLsBd1rekWcuduakTo/dJw6U6sBP3eUq+RXM9RNfPuWTvG2w/WObDkIvJ2KChy6oxZmOSC08Ak2OJA0UiAA=="
-    ],
-
-    "@rollup/rollup-linux-s390x-gnu": [
-      "@rollup/rollup-linux-s390x-gnu@4.45.0",
-      "",
-      { "os": "linux", "cpu": "s390x" },
-      "sha512-2l9sA7d7QdikL0xQwNMO3xURBUNEWyHVHfAsHsUdq+E/pgLTUcCE+gih5PCdmyHmfTDeXUWVhqL0WZzg0nua3g=="
-    ],
-
-    "@rollup/rollup-linux-x64-gnu": [
-      "@rollup/rollup-linux-x64-gnu@4.45.0",
-      "",
-      { "os": "linux", "cpu": "x64" },
-      "sha512-XZdD3fEEQcwG2KrJDdEQu7NrHonPxxaV0/w2HpvINBdcqebz1aL+0vM2WFJq4DeiAVT6F5SUQas65HY5JDqoPw=="
-    ],
-
-    "@rollup/rollup-linux-x64-musl": [
-      "@rollup/rollup-linux-x64-musl@4.45.0",
-      "",
-      { "os": "linux", "cpu": "x64" },
-      "sha512-7ayfgvtmmWgKWBkCGg5+xTQ0r5V1owVm67zTrsEY1008L5ro7mCyGYORomARt/OquB9KY7LpxVBZes+oSniAAQ=="
-    ],
-
-    "@rollup/rollup-win32-arm64-msvc": [
-      "@rollup/rollup-win32-arm64-msvc@4.45.0",
-      "",
-      { "os": "win32", "cpu": "arm64" },
-      "sha512-B+IJgcBnE2bm93jEW5kHisqvPITs4ddLOROAcOc/diBgrEiQJJ6Qcjby75rFSmH5eMGrqJryUgJDhrfj942apQ=="
-    ],
-
-    "@rollup/rollup-win32-ia32-msvc": [
-      "@rollup/rollup-win32-ia32-msvc@4.45.0",
-      "",
-      { "os": "win32", "cpu": "ia32" },
-      "sha512-+CXwwG66g0/FpWOnP/v1HnrGVSOygK/osUbu3wPRy8ECXjoYKjRAyfxYpDQOfghC5qPJYLPH0oN4MCOjwgdMug=="
-    ],
-
-    "@rollup/rollup-win32-x64-msvc": [
-      "@rollup/rollup-win32-x64-msvc@4.45.0",
-      "",
-      { "os": "win32", "cpu": "x64" },
-      "sha512-SRf1cytG7wqcHVLrBc9VtPK4pU5wxiB/lNIkNmW2ApKXIg+RpqwHfsaEK+e7eH4A1BpI6BX/aBWXxZCIrJg3uA=="
-    ],
-
-    "@sindresorhus/is": [
-      "@sindresorhus/is@7.0.2",
-      "",
-      {},
-      "sha512-d9xRovfKNz1SKieM0qJdO+PQonjnnIfSNWfHYnBSJ9hkjm0ZPw6HlxscDXYstp3z+7V2GOFHc+J0CYrYTjqCJw=="
-    ],
-
-    "@speed-highlight/core": [
-      "@speed-highlight/core@1.2.7",
-      "",
-      {},
-      "sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g=="
-    ],
-
-    "@types/body-parser": [
-      "@types/body-parser@1.19.6",
-      "",
-      { "dependencies": { "@types/connect": "*", "@types/node": "*" } },
-      "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="
-    ],
-
-    "@types/connect": [
-      "@types/connect@3.4.38",
-      "",
-      { "dependencies": { "@types/node": "*" } },
-      "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="
-    ],
-
-    "@types/estree": [
-      "@types/estree@1.0.8",
-      "",
-      {},
-      "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="
-    ],
-
-    "@types/express": [
-      "@types/express@4.17.23",
-      "",
-      {
-        "dependencies": {
-          "@types/body-parser": "*",
-          "@types/express-serve-static-core": "^4.17.33",
-          "@types/qs": "*",
-          "@types/serve-static": "*"
-        }
-      },
-      "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ=="
-    ],
-
-    "@types/express-serve-static-core": [
-      "@types/express-serve-static-core@4.19.6",
-      "",
-      {
-        "dependencies": {
-          "@types/node": "*",
-          "@types/qs": "*",
-          "@types/range-parser": "*",
-          "@types/send": "*"
-        }
-      },
-      "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A=="
-    ],
-
-    "@types/http-errors": [
-      "@types/http-errors@2.0.5",
-      "",
-      {},
-      "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="
-    ],
-
-    "@types/mime": [
-      "@types/mime@1.3.5",
-      "",
-      {},
-      "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
-    ],
-
-    "@types/node": [
-      "@types/node@20.19.7",
-      "",
-      { "dependencies": { "undici-types": "~6.21.0" } },
-      "sha512-1GM9z6BJOv86qkPvzh2i6VW5+VVrXxCLknfmTkWEqz+6DqosiY28XUWCTmBcJ0ACzKqx/iwdIREfo1fwExIlkA=="
-    ],
-
-    "@types/qs": [
-      "@types/qs@6.14.0",
-      "",
-      {},
-      "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ=="
-    ],
-
-    "@types/range-parser": [
-      "@types/range-parser@1.2.7",
-      "",
-      {},
-      "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
-    ],
-
-    "@types/send": [
-      "@types/send@0.17.5",
-      "",
-      { "dependencies": { "@types/mime": "^1", "@types/node": "*" } },
-      "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w=="
-    ],
-
-    "@types/serve-static": [
-      "@types/serve-static@1.15.8",
-      "",
-      {
-        "dependencies": {
-          "@types/http-errors": "*",
-          "@types/node": "*",
-          "@types/send": "*"
-        }
-      },
-      "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg=="
-    ],
-
-    "@types/ws": [
-      "@types/ws@8.18.1",
-      "",
-      { "dependencies": { "@types/node": "*" } },
-      "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="
-    ],
-
-    "@wsx-sh/client": ["@wsx-sh/client@workspace:packages/client"],
+    "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.4.0", "", { "dependencies": { "mime": "^3.0.0" } }, "sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA=="],
+
+    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.3.3", "", { "peerDependencies": { "unenv": "2.0.0-rc.17", "workerd": "^1.20250508.0" }, "optionalPeers": ["workerd"] }, "sha512-/M3MEcj3V2WHIRSW1eAQBPRJ6JnGQHc6JKMAPLkDb7pLs3m6X9ES/+K3ceGqxI6TKeF32AWAi7ls0AYzVxCP0A=="],
+
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20250709.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-VqwcvnbI8FNCP87ZWNHA3/sAC5U9wMbNnjBG0sHEYzM7B9RPHKYHdVKdBEWhzZXnkQYMK81IHm4CZsK16XxAuQ=="],
+
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20250709.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-A54ttSgXMM4huChPTThhkieOjpDxR+srVOO9zjTHVIyoQxA8zVsku4CcY/GQ95RczMV+yCKVVu/tAME7vwBFuA=="],
+
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20250709.0", "", { "os": "linux", "cpu": "x64" }, "sha512-no4O3OK+VXINIxv99OHJDpIgML2ZssrSvImwLtULzqm+cl4t1PIfXNRUqj89ujTkmad+L9y4G6dBQMPCLnmlGg=="],
+
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20250709.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-7cNICk2Qd+m4QGrcmWyAuZJXTHt1ud6isA+dic7Yk42WZmwXhlcUATyvFD9FSQNFcldjuRB4n8JlWEFqZBn+lw=="],
+
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20250709.0", "", { "os": "win32", "cpu": "x64" }, "sha512-j1AyO8V/62Q23EJplWgzBlRCqo/diXgox58AbDqSqgyzCBAlvUzXQRDBab/FPNG/erRqt7I1zQhahrBhrM0uLA=="],
+
+    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.4.4", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-hHyapA4A3gPaDCNfiqyZUStTMqIkKRshqPIuDOXv1hcBnD4U3l8cP0T1HMCfGRxQ6V64TGCcoswChANyOAwbQg=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.4", "", { "os": "android", "cpu": "arm" }, "sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.4", "", { "os": "android", "cpu": "arm64" }, "sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.4", "", { "os": "android", "cpu": "x64" }, "sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.4", "", { "os": "linux", "cpu": "arm" }, "sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.4", "", { "os": "linux", "cpu": "ia32" }, "sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.4", "", { "os": "linux", "cpu": "none" }, "sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.4", "", { "os": "linux", "cpu": "none" }, "sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.4", "", { "os": "linux", "cpu": "none" }, "sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.4", "", { "os": "linux", "cpu": "x64" }, "sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.4", "", { "os": "none", "cpu": "arm64" }, "sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.4", "", { "os": "none", "cpu": "x64" }, "sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.4", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.4", "", { "os": "sunos", "cpu": "x64" }, "sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.4", "", { "os": "win32", "cpu": "x64" }, "sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ=="],
+
+    "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.0.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.0.4" }, "os": "darwin", "cpu": "x64" }, "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.0.5", "", { "os": "linux", "cpu": "arm" }, "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.0.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.0.5" }, "os": "linux", "cpu": "arm" }, "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.0.4" }, "os": "linux", "cpu": "s390x" }, "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.33.5", "", { "dependencies": { "@emnapi/runtime": "^1.2.0" }, "cpu": "none" }, "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.33.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.33.5", "", { "os": "win32", "cpu": "x64" }, "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg=="],
+
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.12", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.4", "", {}, "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.29", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ=="],
+
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@poppinss/colors": ["@poppinss/colors@4.1.5", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-FvdDqtcRCtz6hThExcFOgW0cWX+xwSMWcRuQe5ZEb2m7cVQOAVZOIMt+/v9RxGiD9/OY16qJBXK4CVKWAPalBw=="],
+
+    "@poppinss/dumper": ["@poppinss/dumper@0.6.4", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-iG0TIdqv8xJ3Lt9O8DrPRxw1MRLjNpoqiSGU03P/wNLP/s0ra0udPJ1J2Tx5M0J3H/cVyEgpbn8xUKRY9j59kQ=="],
+
+    "@poppinss/exception": ["@poppinss/exception@1.2.2", "", {}, "sha512-m7bpKCD4QMlFCjA/nKTs23fuvoVFoA83brRKmObCUNmi/9tVu8Ve3w4YQAnJu4q3Tjf5fr685HYIC/IA2zHRSg=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.45.0", "", { "os": "android", "cpu": "arm" }, "sha512-2o/FgACbji4tW1dzXOqAV15Eu7DdgbKsF2QKcxfG4xbh5iwU7yr5RRP5/U+0asQliSYv5M4o7BevlGIoSL0LXg=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.45.0", "", { "os": "android", "cpu": "arm64" }, "sha512-PSZ0SvMOjEAxwZeTx32eI/j5xSYtDCRxGu5k9zvzoY77xUNssZM+WV6HYBLROpY5CkXsbQjvz40fBb7WPwDqtQ=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.45.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BA4yPIPssPB2aRAWzmqzQ3y2/KotkLyZukVB7j3psK/U3nVJdceo6qr9pLM2xN6iRP/wKfxEbOb1yrlZH6sYZg=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.45.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Pr2o0lvTwsiG4HCr43Zy9xXrHspyMvsvEw4FwKYqhli4FuLE5FjcZzuQ4cfPe0iUFCvSQG6lACI0xj74FDZKRA=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.45.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-lYE8LkE5h4a/+6VnnLiL14zWMPnx6wNbDG23GcYFpRW1V9hYWHAw9lBZ6ZUIrOaoK7NliF1sdwYGiVmziUF4vA=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.45.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-PVQWZK9sbzpvqC9Q0GlehNNSVHR+4m7+wET+7FgSnKG3ci5nAMgGmr9mGBXzAuE5SvguCKJ6mHL6vq1JaJ/gvw=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.45.0", "", { "os": "linux", "cpu": "arm" }, "sha512-hLrmRl53prCcD+YXTfNvXd776HTxNh8wPAMllusQ+amcQmtgo3V5i/nkhPN6FakW+QVLoUUr2AsbtIRPFU3xIA=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.45.0", "", { "os": "linux", "cpu": "arm" }, "sha512-XBKGSYcrkdiRRjl+8XvrUR3AosXU0NvF7VuqMsm7s5nRy+nt58ZMB19Jdp1RdqewLcaYnpk8zeVs/4MlLZEJxw=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.45.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-fRvZZPUiBz7NztBE/2QnCS5AtqLVhXmUOPj9IHlfGEXkapgImf4W9+FSkL8cWqoAjozyUzqFmSc4zh2ooaeF6g=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.45.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Btv2WRZOcUGi8XU80XwIvzTg4U6+l6D0V6sZTrZx214nrwxw5nAi8hysaXj/mctyClWgesyuxbeLylCBNauimg=="],
+
+    "@rollup/rollup-linux-loongarch64-gnu": ["@rollup/rollup-linux-loongarch64-gnu@4.45.0", "", { "os": "linux", "cpu": "none" }, "sha512-Li0emNnwtUZdLwHjQPBxn4VWztcrw/h7mgLyHiEI5Z0MhpeFGlzaiBHpSNVOMB/xucjXTTcO+dhv469Djr16KA=="],
+
+    "@rollup/rollup-linux-powerpc64le-gnu": ["@rollup/rollup-linux-powerpc64le-gnu@4.45.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-sB8+pfkYx2kvpDCfd63d5ScYT0Fz1LO6jIb2zLZvmK9ob2D8DeVqrmBDE0iDK8KlBVmsTNzrjr3G1xV4eUZhSw=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.45.0", "", { "os": "linux", "cpu": "none" }, "sha512-5GQ6PFhh7E6jQm70p1aW05G2cap5zMOvO0se5JMecHeAdj5ZhWEHbJ4hiKpfi1nnnEdTauDXxPgXae/mqjow9w=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.45.0", "", { "os": "linux", "cpu": "none" }, "sha512-N/euLsBd1rekWcuduakTo/dJw6U6sBP3eUq+RXM9RNfPuWTvG2w/WObDkIvJ2KChy6oxZmOSC08Ak2OJA0UiAA=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.45.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-2l9sA7d7QdikL0xQwNMO3xURBUNEWyHVHfAsHsUdq+E/pgLTUcCE+gih5PCdmyHmfTDeXUWVhqL0WZzg0nua3g=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.45.0", "", { "os": "linux", "cpu": "x64" }, "sha512-XZdD3fEEQcwG2KrJDdEQu7NrHonPxxaV0/w2HpvINBdcqebz1aL+0vM2WFJq4DeiAVT6F5SUQas65HY5JDqoPw=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.45.0", "", { "os": "linux", "cpu": "x64" }, "sha512-7ayfgvtmmWgKWBkCGg5+xTQ0r5V1owVm67zTrsEY1008L5ro7mCyGYORomARt/OquB9KY7LpxVBZes+oSniAAQ=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.45.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-B+IJgcBnE2bm93jEW5kHisqvPITs4ddLOROAcOc/diBgrEiQJJ6Qcjby75rFSmH5eMGrqJryUgJDhrfj942apQ=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.45.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-+CXwwG66g0/FpWOnP/v1HnrGVSOygK/osUbu3wPRy8ECXjoYKjRAyfxYpDQOfghC5qPJYLPH0oN4MCOjwgdMug=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.45.0", "", { "os": "win32", "cpu": "x64" }, "sha512-SRf1cytG7wqcHVLrBc9VtPK4pU5wxiB/lNIkNmW2ApKXIg+RpqwHfsaEK+e7eH4A1BpI6BX/aBWXxZCIrJg3uA=="],
+
+    "@sindresorhus/is": ["@sindresorhus/is@7.0.2", "", {}, "sha512-d9xRovfKNz1SKieM0qJdO+PQonjnnIfSNWfHYnBSJ9hkjm0ZPw6HlxscDXYstp3z+7V2GOFHc+J0CYrYTjqCJw=="],
+
+    "@speed-highlight/core": ["@speed-highlight/core@1.2.7", "", {}, "sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g=="],
+
+    "@stukennedy/wsx-client": ["@stukennedy/wsx-client@workspace:packages/client"],
+
+    "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
+
+    "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/express": ["@types/express@4.17.23", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^4.17.33", "@types/qs": "*", "@types/serve-static": "*" } }, "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ=="],
+
+    "@types/express-serve-static-core": ["@types/express-serve-static-core@4.19.6", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A=="],
+
+    "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
+
+    "@types/mime": ["@types/mime@1.3.5", "", {}, "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="],
+
+    "@types/node": ["@types/node@20.19.7", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-1GM9z6BJOv86qkPvzh2i6VW5+VVrXxCLknfmTkWEqz+6DqosiY28XUWCTmBcJ0ACzKqx/iwdIREfo1fwExIlkA=="],
+
+    "@types/qs": ["@types/qs@6.14.0", "", {}, "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ=="],
+
+    "@types/range-parser": ["@types/range-parser@1.2.7", "", {}, "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="],
+
+    "@types/send": ["@types/send@0.17.5", "", { "dependencies": { "@types/mime": "^1", "@types/node": "*" } }, "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w=="],
+
+    "@types/serve-static": ["@types/serve-static@1.15.8", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "*" } }, "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@wsx-sh/core": ["@wsx-sh/core@workspace:packages/core"],
 
@@ -859,1825 +285,396 @@
 
     "@wsx-sh/hono": ["@wsx-sh/hono@workspace:packages/hono"],
 
-    "accepts": [
-      "accepts@1.3.8",
-      "",
-      { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } },
-      "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="
-    ],
-
-    "acorn": [
-      "acorn@8.14.0",
-      "",
-      { "bin": { "acorn": "bin/acorn" } },
-      "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="
-    ],
-
-    "acorn-walk": [
-      "acorn-walk@8.3.2",
-      "",
-      {},
-      "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A=="
-    ],
-
-    "ansi-regex": [
-      "ansi-regex@6.1.0",
-      "",
-      {},
-      "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="
-    ],
-
-    "ansi-styles": [
-      "ansi-styles@6.2.1",
-      "",
-      {},
-      "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="
-    ],
-
-    "any-promise": [
-      "any-promise@1.3.0",
-      "",
-      {},
-      "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
-    ],
-
-    "array-flatten": [
-      "array-flatten@1.1.1",
-      "",
-      {},
-      "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
-    ],
-
-    "balanced-match": [
-      "balanced-match@1.0.2",
-      "",
-      {},
-      "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    ],
-
-    "blake3-wasm": [
-      "blake3-wasm@2.1.5",
-      "",
-      {},
-      "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="
-    ],
-
-    "body-parser": [
-      "body-parser@1.20.3",
-      "",
-      {
-        "dependencies": {
-          "bytes": "3.1.2",
-          "content-type": "~1.0.5",
-          "debug": "2.6.9",
-          "depd": "2.0.0",
-          "destroy": "1.2.0",
-          "http-errors": "2.0.0",
-          "iconv-lite": "0.4.24",
-          "on-finished": "2.4.1",
-          "qs": "6.13.0",
-          "raw-body": "2.5.2",
-          "type-is": "~1.6.18",
-          "unpipe": "1.0.0"
-        }
-      },
-      "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g=="
-    ],
-
-    "brace-expansion": [
-      "brace-expansion@2.0.2",
-      "",
-      { "dependencies": { "balanced-match": "^1.0.0" } },
-      "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="
-    ],
-
-    "bundle-require": [
-      "bundle-require@5.1.0",
-      "",
-      {
-        "dependencies": { "load-tsconfig": "^0.2.3" },
-        "peerDependencies": { "esbuild": ">=0.18" }
-      },
-      "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="
-    ],
-
-    "bytes": [
-      "bytes@3.1.2",
-      "",
-      {},
-      "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
-    ],
-
-    "cac": [
-      "cac@6.7.14",
-      "",
-      {},
-      "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="
-    ],
-
-    "call-bind-apply-helpers": [
-      "call-bind-apply-helpers@1.0.2",
-      "",
-      { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } },
-      "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="
-    ],
-
-    "call-bound": [
-      "call-bound@1.0.4",
-      "",
-      {
-        "dependencies": {
-          "call-bind-apply-helpers": "^1.0.2",
-          "get-intrinsic": "^1.3.0"
-        }
-      },
-      "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="
-    ],
-
-    "chokidar": [
-      "chokidar@4.0.3",
-      "",
-      { "dependencies": { "readdirp": "^4.0.1" } },
-      "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="
-    ],
-
-    "color": [
-      "color@4.2.3",
-      "",
-      {
-        "dependencies": { "color-convert": "^2.0.1", "color-string": "^1.9.0" }
-      },
-      "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A=="
-    ],
-
-    "color-convert": [
-      "color-convert@2.0.1",
-      "",
-      { "dependencies": { "color-name": "~1.1.4" } },
-      "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="
-    ],
-
-    "color-name": [
-      "color-name@1.1.4",
-      "",
-      {},
-      "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    ],
-
-    "color-string": [
-      "color-string@1.9.1",
-      "",
-      {
-        "dependencies": { "color-name": "^1.0.0", "simple-swizzle": "^0.2.2" }
-      },
-      "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg=="
-    ],
-
-    "commander": [
-      "commander@4.1.1",
-      "",
-      {},
-      "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
-    ],
-
-    "confbox": [
-      "confbox@0.1.8",
-      "",
-      {},
-      "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="
-    ],
-
-    "consola": [
-      "consola@3.4.2",
-      "",
-      {},
-      "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="
-    ],
-
-    "content-disposition": [
-      "content-disposition@0.5.4",
-      "",
-      { "dependencies": { "safe-buffer": "5.2.1" } },
-      "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ=="
-    ],
-
-    "content-type": [
-      "content-type@1.0.5",
-      "",
-      {},
-      "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
-    ],
-
-    "cookie": [
-      "cookie@0.7.1",
-      "",
-      {},
-      "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w=="
-    ],
-
-    "cookie-signature": [
-      "cookie-signature@1.0.6",
-      "",
-      {},
-      "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
-    ],
-
-    "cross-spawn": [
-      "cross-spawn@7.0.6",
-      "",
-      {
-        "dependencies": {
-          "path-key": "^3.1.0",
-          "shebang-command": "^2.0.0",
-          "which": "^2.0.1"
-        }
-      },
-      "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="
-    ],
-
-    "debug": [
-      "debug@4.4.1",
-      "",
-      { "dependencies": { "ms": "^2.1.3" } },
-      "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="
-    ],
-
-    "defu": [
-      "defu@6.1.4",
-      "",
-      {},
-      "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="
-    ],
-
-    "depd": [
-      "depd@2.0.0",
-      "",
-      {},
-      "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-    ],
-
-    "destroy": [
-      "destroy@1.2.0",
-      "",
-      {},
-      "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
-    ],
-
-    "detect-libc": [
-      "detect-libc@2.0.4",
-      "",
-      {},
-      "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="
-    ],
-
-    "dunder-proto": [
-      "dunder-proto@1.0.1",
-      "",
-      {
-        "dependencies": {
-          "call-bind-apply-helpers": "^1.0.1",
-          "es-errors": "^1.3.0",
-          "gopd": "^1.2.0"
-        }
-      },
-      "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="
-    ],
-
-    "eastasianwidth": [
-      "eastasianwidth@0.2.0",
-      "",
-      {},
-      "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
-    ],
-
-    "ee-first": [
-      "ee-first@1.1.1",
-      "",
-      {},
-      "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
-    ],
-
-    "emoji-regex": [
-      "emoji-regex@9.2.2",
-      "",
-      {},
-      "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
-    ],
-
-    "encodeurl": [
-      "encodeurl@2.0.0",
-      "",
-      {},
-      "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
-    ],
-
-    "error-stack-parser-es": [
-      "error-stack-parser-es@1.0.5",
-      "",
-      {},
-      "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="
-    ],
-
-    "es-define-property": [
-      "es-define-property@1.0.1",
-      "",
-      {},
-      "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
-    ],
-
-    "es-errors": [
-      "es-errors@1.3.0",
-      "",
-      {},
-      "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
-    ],
-
-    "es-object-atoms": [
-      "es-object-atoms@1.1.1",
-      "",
-      { "dependencies": { "es-errors": "^1.3.0" } },
-      "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="
-    ],
-
-    "esbuild": [
-      "esbuild@0.25.4",
-      "",
-      {
-        "optionalDependencies": {
-          "@esbuild/aix-ppc64": "0.25.4",
-          "@esbuild/android-arm": "0.25.4",
-          "@esbuild/android-arm64": "0.25.4",
-          "@esbuild/android-x64": "0.25.4",
-          "@esbuild/darwin-arm64": "0.25.4",
-          "@esbuild/darwin-x64": "0.25.4",
-          "@esbuild/freebsd-arm64": "0.25.4",
-          "@esbuild/freebsd-x64": "0.25.4",
-          "@esbuild/linux-arm": "0.25.4",
-          "@esbuild/linux-arm64": "0.25.4",
-          "@esbuild/linux-ia32": "0.25.4",
-          "@esbuild/linux-loong64": "0.25.4",
-          "@esbuild/linux-mips64el": "0.25.4",
-          "@esbuild/linux-ppc64": "0.25.4",
-          "@esbuild/linux-riscv64": "0.25.4",
-          "@esbuild/linux-s390x": "0.25.4",
-          "@esbuild/linux-x64": "0.25.4",
-          "@esbuild/netbsd-arm64": "0.25.4",
-          "@esbuild/netbsd-x64": "0.25.4",
-          "@esbuild/openbsd-arm64": "0.25.4",
-          "@esbuild/openbsd-x64": "0.25.4",
-          "@esbuild/sunos-x64": "0.25.4",
-          "@esbuild/win32-arm64": "0.25.4",
-          "@esbuild/win32-ia32": "0.25.4",
-          "@esbuild/win32-x64": "0.25.4"
-        },
-        "bin": { "esbuild": "bin/esbuild" }
-      },
-      "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q=="
-    ],
-
-    "escape-html": [
-      "escape-html@1.0.3",
-      "",
-      {},
-      "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
-    ],
-
-    "etag": [
-      "etag@1.8.1",
-      "",
-      {},
-      "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
-    ],
-
-    "exit-hook": [
-      "exit-hook@2.2.1",
-      "",
-      {},
-      "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw=="
-    ],
-
-    "express": [
-      "express@4.21.2",
-      "",
-      {
-        "dependencies": {
-          "accepts": "~1.3.8",
-          "array-flatten": "1.1.1",
-          "body-parser": "1.20.3",
-          "content-disposition": "0.5.4",
-          "content-type": "~1.0.4",
-          "cookie": "0.7.1",
-          "cookie-signature": "1.0.6",
-          "debug": "2.6.9",
-          "depd": "2.0.0",
-          "encodeurl": "~2.0.0",
-          "escape-html": "~1.0.3",
-          "etag": "~1.8.1",
-          "finalhandler": "1.3.1",
-          "fresh": "0.5.2",
-          "http-errors": "2.0.0",
-          "merge-descriptors": "1.0.3",
-          "methods": "~1.1.2",
-          "on-finished": "2.4.1",
-          "parseurl": "~1.3.3",
-          "path-to-regexp": "0.1.12",
-          "proxy-addr": "~2.0.7",
-          "qs": "6.13.0",
-          "range-parser": "~1.2.1",
-          "safe-buffer": "5.2.1",
-          "send": "0.19.0",
-          "serve-static": "1.16.2",
-          "setprototypeof": "1.2.0",
-          "statuses": "2.0.1",
-          "type-is": "~1.6.18",
-          "utils-merge": "1.0.1",
-          "vary": "~1.1.2"
-        }
-      },
-      "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA=="
-    ],
-
-    "exsolve": [
-      "exsolve@1.0.7",
-      "",
-      {},
-      "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw=="
-    ],
-
-    "fdir": [
-      "fdir@6.4.6",
-      "",
-      {
-        "peerDependencies": { "picomatch": "^3 || ^4" },
-        "optionalPeers": ["picomatch"]
-      },
-      "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w=="
-    ],
-
-    "finalhandler": [
-      "finalhandler@1.3.1",
-      "",
-      {
-        "dependencies": {
-          "debug": "2.6.9",
-          "encodeurl": "~2.0.0",
-          "escape-html": "~1.0.3",
-          "on-finished": "2.4.1",
-          "parseurl": "~1.3.3",
-          "statuses": "2.0.1",
-          "unpipe": "~1.0.0"
-        }
-      },
-      "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ=="
-    ],
-
-    "fix-dts-default-cjs-exports": [
-      "fix-dts-default-cjs-exports@1.0.1",
-      "",
-      {
-        "dependencies": {
-          "magic-string": "^0.30.17",
-          "mlly": "^1.7.4",
-          "rollup": "^4.34.8"
-        }
-      },
-      "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="
-    ],
-
-    "foreground-child": [
-      "foreground-child@3.3.1",
-      "",
-      { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } },
-      "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="
-    ],
-
-    "forwarded": [
-      "forwarded@0.2.0",
-      "",
-      {},
-      "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
-    ],
-
-    "fresh": [
-      "fresh@0.5.2",
-      "",
-      {},
-      "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
-    ],
-
-    "fsevents": [
-      "fsevents@2.3.3",
-      "",
-      { "os": "darwin" },
-      "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="
-    ],
-
-    "function-bind": [
-      "function-bind@1.1.2",
-      "",
-      {},
-      "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
-    ],
-
-    "get-intrinsic": [
-      "get-intrinsic@1.3.0",
-      "",
-      {
-        "dependencies": {
-          "call-bind-apply-helpers": "^1.0.2",
-          "es-define-property": "^1.0.1",
-          "es-errors": "^1.3.0",
-          "es-object-atoms": "^1.1.1",
-          "function-bind": "^1.1.2",
-          "get-proto": "^1.0.1",
-          "gopd": "^1.2.0",
-          "has-symbols": "^1.1.0",
-          "hasown": "^2.0.2",
-          "math-intrinsics": "^1.1.0"
-        }
-      },
-      "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="
-    ],
-
-    "get-proto": [
-      "get-proto@1.0.1",
-      "",
-      {
-        "dependencies": {
-          "dunder-proto": "^1.0.1",
-          "es-object-atoms": "^1.0.0"
-        }
-      },
-      "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="
-    ],
-
-    "glob": [
-      "glob@10.4.5",
-      "",
-      {
-        "dependencies": {
-          "foreground-child": "^3.1.0",
-          "jackspeak": "^3.1.2",
-          "minimatch": "^9.0.4",
-          "minipass": "^7.1.2",
-          "package-json-from-dist": "^1.0.0",
-          "path-scurry": "^1.11.1"
-        },
-        "bin": { "glob": "dist/esm/bin.mjs" }
-      },
-      "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg=="
-    ],
-
-    "glob-to-regexp": [
-      "glob-to-regexp@0.4.1",
-      "",
-      {},
-      "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
-    ],
-
-    "gopd": [
-      "gopd@1.2.0",
-      "",
-      {},
-      "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
-    ],
-
-    "has-symbols": [
-      "has-symbols@1.1.0",
-      "",
-      {},
-      "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
-    ],
-
-    "hasown": [
-      "hasown@2.0.2",
-      "",
-      { "dependencies": { "function-bind": "^1.1.2" } },
-      "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="
-    ],
-
-    "hono": [
-      "hono@4.8.4",
-      "",
-      {},
-      "sha512-KOIBp1+iUs0HrKztM4EHiB2UtzZDTBihDtOF5K6+WaJjCPeaW4Q92R8j63jOhvJI5+tZSMuKD9REVEXXY9illg=="
-    ],
-
-    "http-errors": [
-      "http-errors@2.0.0",
-      "",
-      {
-        "dependencies": {
-          "depd": "2.0.0",
-          "inherits": "2.0.4",
-          "setprototypeof": "1.2.0",
-          "statuses": "2.0.1",
-          "toidentifier": "1.0.1"
-        }
-      },
-      "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ=="
-    ],
-
-    "iconv-lite": [
-      "iconv-lite@0.4.24",
-      "",
-      { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } },
-      "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="
-    ],
-
-    "inherits": [
-      "inherits@2.0.4",
-      "",
-      {},
-      "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    ],
-
-    "ipaddr.js": [
-      "ipaddr.js@1.9.1",
-      "",
-      {},
-      "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
-    ],
-
-    "is-arrayish": [
-      "is-arrayish@0.3.2",
-      "",
-      {},
-      "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
-    ],
-
-    "is-fullwidth-code-point": [
-      "is-fullwidth-code-point@3.0.0",
-      "",
-      {},
-      "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-    ],
-
-    "isexe": [
-      "isexe@2.0.0",
-      "",
-      {},
-      "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
-    ],
-
-    "jackspeak": [
-      "jackspeak@3.4.3",
-      "",
-      {
-        "dependencies": { "@isaacs/cliui": "^8.0.2" },
-        "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" }
-      },
-      "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="
-    ],
-
-    "joycon": [
-      "joycon@3.1.1",
-      "",
-      {},
-      "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="
-    ],
-
-    "kleur": [
-      "kleur@4.1.5",
-      "",
-      {},
-      "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="
-    ],
-
-    "lilconfig": [
-      "lilconfig@3.1.3",
-      "",
-      {},
-      "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="
-    ],
-
-    "lines-and-columns": [
-      "lines-and-columns@1.2.4",
-      "",
-      {},
-      "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
-    ],
-
-    "load-tsconfig": [
-      "load-tsconfig@0.2.5",
-      "",
-      {},
-      "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg=="
-    ],
-
-    "lodash.sortby": [
-      "lodash.sortby@4.7.0",
-      "",
-      {},
-      "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
-    ],
-
-    "lru-cache": [
-      "lru-cache@10.4.3",
-      "",
-      {},
-      "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
-    ],
-
-    "magic-string": [
-      "magic-string@0.30.17",
-      "",
-      { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } },
-      "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="
-    ],
-
-    "math-intrinsics": [
-      "math-intrinsics@1.1.0",
-      "",
-      {},
-      "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
-    ],
-
-    "media-typer": [
-      "media-typer@0.3.0",
-      "",
-      {},
-      "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="
-    ],
-
-    "merge-descriptors": [
-      "merge-descriptors@1.0.3",
-      "",
-      {},
-      "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ=="
-    ],
-
-    "methods": [
-      "methods@1.1.2",
-      "",
-      {},
-      "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
-    ],
-
-    "mime": [
-      "mime@1.6.0",
-      "",
-      { "bin": { "mime": "cli.js" } },
-      "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
-    ],
-
-    "mime-db": [
-      "mime-db@1.52.0",
-      "",
-      {},
-      "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
-    ],
-
-    "mime-types": [
-      "mime-types@2.1.35",
-      "",
-      { "dependencies": { "mime-db": "1.52.0" } },
-      "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="
-    ],
-
-    "miniflare": [
-      "miniflare@4.20250709.0",
-      "",
-      {
-        "dependencies": {
-          "@cspotcode/source-map-support": "0.8.1",
-          "acorn": "8.14.0",
-          "acorn-walk": "8.3.2",
-          "exit-hook": "2.2.1",
-          "glob-to-regexp": "0.4.1",
-          "sharp": "^0.33.5",
-          "stoppable": "1.1.0",
-          "undici": "^5.28.5",
-          "workerd": "1.20250709.0",
-          "ws": "8.18.0",
-          "youch": "4.1.0-beta.10",
-          "zod": "3.22.3"
-        },
-        "bin": { "miniflare": "bootstrap.js" }
-      },
-      "sha512-dRGXi6Do9ArQZt7205QGWZ1tD6k6xQNY/mAZBAtiaQYvKxFuNyiHYlFnSN8Co4AFCVOozo/U52sVAaHvlcmnew=="
-    ],
-
-    "minimatch": [
-      "minimatch@9.0.5",
-      "",
-      { "dependencies": { "brace-expansion": "^2.0.1" } },
-      "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="
-    ],
-
-    "minipass": [
-      "minipass@7.1.2",
-      "",
-      {},
-      "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="
-    ],
-
-    "mlly": [
-      "mlly@1.7.4",
-      "",
-      {
-        "dependencies": {
-          "acorn": "^8.14.0",
-          "pathe": "^2.0.1",
-          "pkg-types": "^1.3.0",
-          "ufo": "^1.5.4"
-        }
-      },
-      "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw=="
-    ],
-
-    "ms": [
-      "ms@2.1.3",
-      "",
-      {},
-      "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    ],
-
-    "mz": [
-      "mz@2.7.0",
-      "",
-      {
-        "dependencies": {
-          "any-promise": "^1.0.0",
-          "object-assign": "^4.0.1",
-          "thenify-all": "^1.0.0"
-        }
-      },
-      "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="
-    ],
-
-    "negotiator": [
-      "negotiator@0.6.3",
-      "",
-      {},
-      "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
-    ],
-
-    "object-assign": [
-      "object-assign@4.1.1",
-      "",
-      {},
-      "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
-    ],
-
-    "object-inspect": [
-      "object-inspect@1.13.4",
-      "",
-      {},
-      "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
-    ],
-
-    "ohash": [
-      "ohash@2.0.11",
-      "",
-      {},
-      "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="
-    ],
-
-    "on-finished": [
-      "on-finished@2.4.1",
-      "",
-      { "dependencies": { "ee-first": "1.1.1" } },
-      "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="
-    ],
-
-    "package-json-from-dist": [
-      "package-json-from-dist@1.0.1",
-      "",
-      {},
-      "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="
-    ],
-
-    "parseurl": [
-      "parseurl@1.3.3",
-      "",
-      {},
-      "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
-    ],
-
-    "path-key": [
-      "path-key@3.1.1",
-      "",
-      {},
-      "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
-    ],
-
-    "path-scurry": [
-      "path-scurry@1.11.1",
-      "",
-      {
-        "dependencies": {
-          "lru-cache": "^10.2.0",
-          "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-        }
-      },
-      "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="
-    ],
-
-    "path-to-regexp": [
-      "path-to-regexp@0.1.12",
-      "",
-      {},
-      "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
-    ],
-
-    "pathe": [
-      "pathe@2.0.3",
-      "",
-      {},
-      "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="
-    ],
-
-    "picocolors": [
-      "picocolors@1.1.1",
-      "",
-      {},
-      "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
-    ],
-
-    "picomatch": [
-      "picomatch@4.0.2",
-      "",
-      {},
-      "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="
-    ],
-
-    "pirates": [
-      "pirates@4.0.7",
-      "",
-      {},
-      "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="
-    ],
-
-    "pkg-types": [
-      "pkg-types@1.3.1",
-      "",
-      {
-        "dependencies": {
-          "confbox": "^0.1.8",
-          "mlly": "^1.7.4",
-          "pathe": "^2.0.1"
-        }
-      },
-      "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="
-    ],
-
-    "postcss-load-config": [
-      "postcss-load-config@6.0.1",
-      "",
-      {
-        "dependencies": { "lilconfig": "^3.1.1" },
-        "peerDependencies": {
-          "jiti": ">=1.21.0",
-          "postcss": ">=8.0.9",
-          "tsx": "^4.8.1",
-          "yaml": "^2.4.2"
-        },
-        "optionalPeers": ["jiti", "postcss", "tsx", "yaml"]
-      },
-      "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="
-    ],
-
-    "proxy-addr": [
-      "proxy-addr@2.0.7",
-      "",
-      { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } },
-      "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="
-    ],
-
-    "punycode": [
-      "punycode@2.3.1",
-      "",
-      {},
-      "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
-    ],
-
-    "qs": [
-      "qs@6.13.0",
-      "",
-      { "dependencies": { "side-channel": "^1.0.6" } },
-      "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg=="
-    ],
-
-    "range-parser": [
-      "range-parser@1.2.1",
-      "",
-      {},
-      "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
-    ],
-
-    "raw-body": [
-      "raw-body@2.5.2",
-      "",
-      {
-        "dependencies": {
-          "bytes": "3.1.2",
-          "http-errors": "2.0.0",
-          "iconv-lite": "0.4.24",
-          "unpipe": "1.0.0"
-        }
-      },
-      "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA=="
-    ],
-
-    "readdirp": [
-      "readdirp@4.1.2",
-      "",
-      {},
-      "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="
-    ],
-
-    "resolve-from": [
-      "resolve-from@5.0.0",
-      "",
-      {},
-      "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
-    ],
-
-    "rollup": [
-      "rollup@4.45.0",
-      "",
-      {
-        "dependencies": { "@types/estree": "1.0.8" },
-        "optionalDependencies": {
-          "@rollup/rollup-android-arm-eabi": "4.45.0",
-          "@rollup/rollup-android-arm64": "4.45.0",
-          "@rollup/rollup-darwin-arm64": "4.45.0",
-          "@rollup/rollup-darwin-x64": "4.45.0",
-          "@rollup/rollup-freebsd-arm64": "4.45.0",
-          "@rollup/rollup-freebsd-x64": "4.45.0",
-          "@rollup/rollup-linux-arm-gnueabihf": "4.45.0",
-          "@rollup/rollup-linux-arm-musleabihf": "4.45.0",
-          "@rollup/rollup-linux-arm64-gnu": "4.45.0",
-          "@rollup/rollup-linux-arm64-musl": "4.45.0",
-          "@rollup/rollup-linux-loongarch64-gnu": "4.45.0",
-          "@rollup/rollup-linux-powerpc64le-gnu": "4.45.0",
-          "@rollup/rollup-linux-riscv64-gnu": "4.45.0",
-          "@rollup/rollup-linux-riscv64-musl": "4.45.0",
-          "@rollup/rollup-linux-s390x-gnu": "4.45.0",
-          "@rollup/rollup-linux-x64-gnu": "4.45.0",
-          "@rollup/rollup-linux-x64-musl": "4.45.0",
-          "@rollup/rollup-win32-arm64-msvc": "4.45.0",
-          "@rollup/rollup-win32-ia32-msvc": "4.45.0",
-          "@rollup/rollup-win32-x64-msvc": "4.45.0",
-          "fsevents": "~2.3.2"
-        },
-        "bin": { "rollup": "dist/bin/rollup" }
-      },
-      "sha512-WLjEcJRIo7i3WDDgOIJqVI2d+lAC3EwvOGy+Xfq6hs+GQuAA4Di/H72xmXkOhrIWFg2PFYSKZYfH0f4vfKXN4A=="
-    ],
-
-    "safe-buffer": [
-      "safe-buffer@5.2.1",
-      "",
-      {},
-      "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-    ],
-
-    "safer-buffer": [
-      "safer-buffer@2.1.2",
-      "",
-      {},
-      "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    ],
-
-    "semver": [
-      "semver@7.7.2",
-      "",
-      { "bin": { "semver": "bin/semver.js" } },
-      "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="
-    ],
-
-    "send": [
-      "send@0.19.0",
-      "",
-      {
-        "dependencies": {
-          "debug": "2.6.9",
-          "depd": "2.0.0",
-          "destroy": "1.2.0",
-          "encodeurl": "~1.0.2",
-          "escape-html": "~1.0.3",
-          "etag": "~1.8.1",
-          "fresh": "0.5.2",
-          "http-errors": "2.0.0",
-          "mime": "1.6.0",
-          "ms": "2.1.3",
-          "on-finished": "2.4.1",
-          "range-parser": "~1.2.1",
-          "statuses": "2.0.1"
-        }
-      },
-      "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw=="
-    ],
-
-    "serve-static": [
-      "serve-static@1.16.2",
-      "",
-      {
-        "dependencies": {
-          "encodeurl": "~2.0.0",
-          "escape-html": "~1.0.3",
-          "parseurl": "~1.3.3",
-          "send": "0.19.0"
-        }
-      },
-      "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw=="
-    ],
-
-    "setprototypeof": [
-      "setprototypeof@1.2.0",
-      "",
-      {},
-      "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
-    ],
-
-    "sharp": [
-      "sharp@0.33.5",
-      "",
-      {
-        "dependencies": {
-          "color": "^4.2.3",
-          "detect-libc": "^2.0.3",
-          "semver": "^7.6.3"
-        },
-        "optionalDependencies": {
-          "@img/sharp-darwin-arm64": "0.33.5",
-          "@img/sharp-darwin-x64": "0.33.5",
-          "@img/sharp-libvips-darwin-arm64": "1.0.4",
-          "@img/sharp-libvips-darwin-x64": "1.0.4",
-          "@img/sharp-libvips-linux-arm": "1.0.5",
-          "@img/sharp-libvips-linux-arm64": "1.0.4",
-          "@img/sharp-libvips-linux-s390x": "1.0.4",
-          "@img/sharp-libvips-linux-x64": "1.0.4",
-          "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
-          "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
-          "@img/sharp-linux-arm": "0.33.5",
-          "@img/sharp-linux-arm64": "0.33.5",
-          "@img/sharp-linux-s390x": "0.33.5",
-          "@img/sharp-linux-x64": "0.33.5",
-          "@img/sharp-linuxmusl-arm64": "0.33.5",
-          "@img/sharp-linuxmusl-x64": "0.33.5",
-          "@img/sharp-wasm32": "0.33.5",
-          "@img/sharp-win32-ia32": "0.33.5",
-          "@img/sharp-win32-x64": "0.33.5"
-        }
-      },
-      "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw=="
-    ],
-
-    "shebang-command": [
-      "shebang-command@2.0.0",
-      "",
-      { "dependencies": { "shebang-regex": "^3.0.0" } },
-      "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="
-    ],
-
-    "shebang-regex": [
-      "shebang-regex@3.0.0",
-      "",
-      {},
-      "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
-    ],
-
-    "side-channel": [
-      "side-channel@1.1.0",
-      "",
-      {
-        "dependencies": {
-          "es-errors": "^1.3.0",
-          "object-inspect": "^1.13.3",
-          "side-channel-list": "^1.0.0",
-          "side-channel-map": "^1.0.1",
-          "side-channel-weakmap": "^1.0.2"
-        }
-      },
-      "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="
-    ],
-
-    "side-channel-list": [
-      "side-channel-list@1.0.0",
-      "",
-      {
-        "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" }
-      },
-      "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="
-    ],
-
-    "side-channel-map": [
-      "side-channel-map@1.0.1",
-      "",
-      {
-        "dependencies": {
-          "call-bound": "^1.0.2",
-          "es-errors": "^1.3.0",
-          "get-intrinsic": "^1.2.5",
-          "object-inspect": "^1.13.3"
-        }
-      },
-      "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="
-    ],
-
-    "side-channel-weakmap": [
-      "side-channel-weakmap@1.0.2",
-      "",
-      {
-        "dependencies": {
-          "call-bound": "^1.0.2",
-          "es-errors": "^1.3.0",
-          "get-intrinsic": "^1.2.5",
-          "object-inspect": "^1.13.3",
-          "side-channel-map": "^1.0.1"
-        }
-      },
-      "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="
-    ],
-
-    "signal-exit": [
-      "signal-exit@4.1.0",
-      "",
-      {},
-      "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
-    ],
-
-    "simple-swizzle": [
-      "simple-swizzle@0.2.2",
-      "",
-      { "dependencies": { "is-arrayish": "^0.3.1" } },
-      "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg=="
-    ],
-
-    "source-map": [
-      "source-map@0.8.0-beta.0",
-      "",
-      { "dependencies": { "whatwg-url": "^7.0.0" } },
-      "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA=="
-    ],
-
-    "statuses": [
-      "statuses@2.0.1",
-      "",
-      {},
-      "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
-    ],
-
-    "stoppable": [
-      "stoppable@1.1.0",
-      "",
-      {},
-      "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="
-    ],
-
-    "string-width": [
-      "string-width@5.1.2",
-      "",
-      {
-        "dependencies": {
-          "eastasianwidth": "^0.2.0",
-          "emoji-regex": "^9.2.2",
-          "strip-ansi": "^7.0.1"
-        }
-      },
-      "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="
-    ],
-
-    "string-width-cjs": [
-      "string-width@4.2.3",
-      "",
-      {
-        "dependencies": {
-          "emoji-regex": "^8.0.0",
-          "is-fullwidth-code-point": "^3.0.0",
-          "strip-ansi": "^6.0.1"
-        }
-      },
-      "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="
-    ],
-
-    "strip-ansi": [
-      "strip-ansi@7.1.0",
-      "",
-      { "dependencies": { "ansi-regex": "^6.0.1" } },
-      "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="
-    ],
-
-    "strip-ansi-cjs": [
-      "strip-ansi@6.0.1",
-      "",
-      { "dependencies": { "ansi-regex": "^5.0.1" } },
-      "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="
-    ],
-
-    "sucrase": [
-      "sucrase@3.35.0",
-      "",
-      {
-        "dependencies": {
-          "@jridgewell/gen-mapping": "^0.3.2",
-          "commander": "^4.0.0",
-          "glob": "^10.3.10",
-          "lines-and-columns": "^1.1.6",
-          "mz": "^2.7.0",
-          "pirates": "^4.0.1",
-          "ts-interface-checker": "^0.1.9"
-        },
-        "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" }
-      },
-      "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA=="
-    ],
-
-    "supports-color": [
-      "supports-color@10.0.0",
-      "",
-      {},
-      "sha512-HRVVSbCCMbj7/kdWF9Q+bbckjBHLtHMEoJWlkmYzzdwhYMkjkOwubLM6t7NbWKjgKamGDrWL1++KrjUO1t9oAQ=="
-    ],
-
-    "thenify": [
-      "thenify@3.3.1",
-      "",
-      { "dependencies": { "any-promise": "^1.0.0" } },
-      "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="
-    ],
-
-    "thenify-all": [
-      "thenify-all@1.6.0",
-      "",
-      { "dependencies": { "thenify": ">= 3.1.0 < 4" } },
-      "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="
-    ],
-
-    "tinyexec": [
-      "tinyexec@0.3.2",
-      "",
-      {},
-      "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="
-    ],
-
-    "tinyglobby": [
-      "tinyglobby@0.2.14",
-      "",
-      { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } },
-      "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ=="
-    ],
-
-    "toidentifier": [
-      "toidentifier@1.0.1",
-      "",
-      {},
-      "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
-    ],
-
-    "tr46": [
-      "tr46@1.0.1",
-      "",
-      { "dependencies": { "punycode": "^2.1.0" } },
-      "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA=="
-    ],
-
-    "tree-kill": [
-      "tree-kill@1.2.2",
-      "",
-      { "bin": { "tree-kill": "cli.js" } },
-      "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="
-    ],
-
-    "ts-interface-checker": [
-      "ts-interface-checker@0.1.13",
-      "",
-      {},
-      "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
-    ],
-
-    "tslib": [
-      "tslib@2.8.1",
-      "",
-      {},
-      "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-    ],
-
-    "tsup": [
-      "tsup@8.5.0",
-      "",
-      {
-        "dependencies": {
-          "bundle-require": "^5.1.0",
-          "cac": "^6.7.14",
-          "chokidar": "^4.0.3",
-          "consola": "^3.4.0",
-          "debug": "^4.4.0",
-          "esbuild": "^0.25.0",
-          "fix-dts-default-cjs-exports": "^1.0.0",
-          "joycon": "^3.1.1",
-          "picocolors": "^1.1.1",
-          "postcss-load-config": "^6.0.1",
-          "resolve-from": "^5.0.0",
-          "rollup": "^4.34.8",
-          "source-map": "0.8.0-beta.0",
-          "sucrase": "^3.35.0",
-          "tinyexec": "^0.3.2",
-          "tinyglobby": "^0.2.11",
-          "tree-kill": "^1.2.2"
-        },
-        "peerDependencies": {
-          "@microsoft/api-extractor": "^7.36.0",
-          "@swc/core": "^1",
-          "postcss": "^8.4.12",
-          "typescript": ">=4.5.0"
-        },
-        "optionalPeers": [
-          "@microsoft/api-extractor",
-          "@swc/core",
-          "postcss",
-          "typescript"
-        ],
-        "bin": {
-          "tsup": "dist/cli-default.js",
-          "tsup-node": "dist/cli-node.js"
-        }
-      },
-      "sha512-VmBp77lWNQq6PfuMqCHD3xWl22vEoWsKajkF8t+yMBawlUS8JzEI+vOVMeuNZIuMML8qXRizFKi9oD5glKQVcQ=="
-    ],
-
-    "type-is": [
-      "type-is@1.6.18",
-      "",
-      { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } },
-      "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="
-    ],
-
-    "typescript": [
-      "typescript@5.8.3",
-      "",
-      { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } },
-      "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="
-    ],
-
-    "ufo": [
-      "ufo@1.6.1",
-      "",
-      {},
-      "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="
-    ],
-
-    "undici": [
-      "undici@5.29.0",
-      "",
-      { "dependencies": { "@fastify/busboy": "^2.0.0" } },
-      "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="
-    ],
-
-    "undici-types": [
-      "undici-types@6.21.0",
-      "",
-      {},
-      "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
-    ],
-
-    "unenv": [
-      "unenv@2.0.0-rc.17",
-      "",
-      {
-        "dependencies": {
-          "defu": "^6.1.4",
-          "exsolve": "^1.0.4",
-          "ohash": "^2.0.11",
-          "pathe": "^2.0.3",
-          "ufo": "^1.6.1"
-        }
-      },
-      "sha512-B06u0wXkEd+o5gOCMl/ZHl5cfpYbDZKAT+HWTL+Hws6jWu7dCiqBBXXXzMFcFVJb8D4ytAnYmxJA83uwOQRSsg=="
-    ],
-
-    "unpipe": [
-      "unpipe@1.0.0",
-      "",
-      {},
-      "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
-    ],
-
-    "utils-merge": [
-      "utils-merge@1.0.1",
-      "",
-      {},
-      "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
-    ],
-
-    "vary": [
-      "vary@1.1.2",
-      "",
-      {},
-      "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
-    ],
-
-    "webidl-conversions": [
-      "webidl-conversions@4.0.2",
-      "",
-      {},
-      "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
-    ],
-
-    "whatwg-url": [
-      "whatwg-url@7.1.0",
-      "",
-      {
-        "dependencies": {
-          "lodash.sortby": "^4.7.0",
-          "tr46": "^1.0.1",
-          "webidl-conversions": "^4.0.2"
-        }
-      },
-      "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg=="
-    ],
-
-    "which": [
-      "which@2.0.2",
-      "",
-      {
-        "dependencies": { "isexe": "^2.0.0" },
-        "bin": { "node-which": "./bin/node-which" }
-      },
-      "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="
-    ],
-
-    "workerd": [
-      "workerd@1.20250709.0",
-      "",
-      {
-        "optionalDependencies": {
-          "@cloudflare/workerd-darwin-64": "1.20250709.0",
-          "@cloudflare/workerd-darwin-arm64": "1.20250709.0",
-          "@cloudflare/workerd-linux-64": "1.20250709.0",
-          "@cloudflare/workerd-linux-arm64": "1.20250709.0",
-          "@cloudflare/workerd-windows-64": "1.20250709.0"
-        },
-        "bin": { "workerd": "bin/workerd" }
-      },
-      "sha512-BqLPpmvRN+TYUSG61OkWamsGdEuMwgvabP8m0QOHIfofnrD2YVyWqE1kXJ0GH5EsVEuWamE5sR8XpTfsGBmIpg=="
-    ],
-
-    "wrangler": [
-      "wrangler@4.24.3",
-      "",
-      {
-        "dependencies": {
-          "@cloudflare/kv-asset-handler": "0.4.0",
-          "@cloudflare/unenv-preset": "2.3.3",
-          "blake3-wasm": "2.1.5",
-          "esbuild": "0.25.4",
-          "miniflare": "4.20250709.0",
-          "path-to-regexp": "6.3.0",
-          "unenv": "2.0.0-rc.17",
-          "workerd": "1.20250709.0"
-        },
-        "optionalDependencies": { "fsevents": "~2.3.2" },
-        "peerDependencies": { "@cloudflare/workers-types": "^4.20250709.0" },
-        "optionalPeers": ["@cloudflare/workers-types"],
-        "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" }
-      },
-      "sha512-stB1Wfs5NKlspsAzz8SBujBKsDqT5lpCyrL+vSUMy3uueEtI1A5qyORbKoJhIguEbwHfWS39mBsxzm6Vm1J2cg=="
-    ],
-
-    "wrap-ansi": [
-      "wrap-ansi@8.1.0",
-      "",
-      {
-        "dependencies": {
-          "ansi-styles": "^6.1.0",
-          "string-width": "^5.0.1",
-          "strip-ansi": "^7.0.1"
-        }
-      },
-      "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="
-    ],
-
-    "wrap-ansi-cjs": [
-      "wrap-ansi@7.0.0",
-      "",
-      {
-        "dependencies": {
-          "ansi-styles": "^4.0.0",
-          "string-width": "^4.1.0",
-          "strip-ansi": "^6.0.0"
-        }
-      },
-      "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="
-    ],
-
-    "ws": [
-      "ws@8.18.0",
-      "",
-      {
-        "peerDependencies": {
-          "bufferutil": "^4.0.1",
-          "utf-8-validate": ">=5.0.2"
-        },
-        "optionalPeers": ["bufferutil", "utf-8-validate"]
-      },
-      "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="
-    ],
+    "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
+
+    "acorn": ["acorn@8.14.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="],
+
+    "acorn-walk": ["acorn-walk@8.3.2", "", {}, "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A=="],
+
+    "ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
+
+    "ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
+    "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
+
+    "array-flatten": ["array-flatten@1.1.1", "", {}, "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
+
+    "body-parser": ["body-parser@1.20.3", "", { "dependencies": { "bytes": "3.1.2", "content-type": "~1.0.5", "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "http-errors": "2.0.0", "iconv-lite": "0.4.24", "on-finished": "2.4.1", "qs": "6.13.0", "raw-body": "2.5.2", "type-is": "~1.6.18", "unpipe": "1.0.0" } }, "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g=="],
+
+    "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
+
+    "color": ["color@4.2.3", "", { "dependencies": { "color-convert": "^2.0.1", "color-string": "^1.9.0" } }, "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "color-string": ["color-string@1.9.1", "", { "dependencies": { "color-name": "^1.0.0", "simple-swizzle": "^0.2.2" } }, "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg=="],
+
+    "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
+
+    "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
+
+    "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
+
+    "content-disposition": ["content-disposition@0.5.4", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.1", "", {}, "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w=="],
+
+    "cookie-signature": ["cookie-signature@1.0.6", "", {}, "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+
+    "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "destroy": ["destroy@1.2.0", "", {}, "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="],
+
+    "detect-libc": ["detect-libc@2.0.4", "", {}, "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "esbuild": ["esbuild@0.25.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.4", "@esbuild/android-arm": "0.25.4", "@esbuild/android-arm64": "0.25.4", "@esbuild/android-x64": "0.25.4", "@esbuild/darwin-arm64": "0.25.4", "@esbuild/darwin-x64": "0.25.4", "@esbuild/freebsd-arm64": "0.25.4", "@esbuild/freebsd-x64": "0.25.4", "@esbuild/linux-arm": "0.25.4", "@esbuild/linux-arm64": "0.25.4", "@esbuild/linux-ia32": "0.25.4", "@esbuild/linux-loong64": "0.25.4", "@esbuild/linux-mips64el": "0.25.4", "@esbuild/linux-ppc64": "0.25.4", "@esbuild/linux-riscv64": "0.25.4", "@esbuild/linux-s390x": "0.25.4", "@esbuild/linux-x64": "0.25.4", "@esbuild/netbsd-arm64": "0.25.4", "@esbuild/netbsd-x64": "0.25.4", "@esbuild/openbsd-arm64": "0.25.4", "@esbuild/openbsd-x64": "0.25.4", "@esbuild/sunos-x64": "0.25.4", "@esbuild/win32-arm64": "0.25.4", "@esbuild/win32-ia32": "0.25.4", "@esbuild/win32-x64": "0.25.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "exit-hook": ["exit-hook@2.2.1", "", {}, "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw=="],
+
+    "express": ["express@4.21.2", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "1.20.3", "content-disposition": "0.5.4", "content-type": "~1.0.4", "cookie": "0.7.1", "cookie-signature": "1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "1.3.1", "fresh": "0.5.2", "http-errors": "2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "0.1.12", "proxy-addr": "~2.0.7", "qs": "6.13.0", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "0.19.0", "serve-static": "1.16.2", "setprototypeof": "1.2.0", "statuses": "2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA=="],
+
+    "exsolve": ["exsolve@1.0.7", "", {}, "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw=="],
+
+    "fdir": ["fdir@6.4.6", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w=="],
+
+    "finalhandler": ["finalhandler@1.3.1", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "on-finished": "2.4.1", "parseurl": "~1.3.3", "statuses": "2.0.1", "unpipe": "~1.0.0" } }, "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ=="],
+
+    "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
+
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "glob": ["glob@10.4.5", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg=="],
+
+    "glob-to-regexp": ["glob-to-regexp@0.4.1", "", {}, "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hono": ["hono@4.8.4", "", {}, "sha512-KOIBp1+iUs0HrKztM4EHiB2UtzZDTBihDtOF5K6+WaJjCPeaW4Q92R8j63jOhvJI5+tZSMuKD9REVEXXY9illg=="],
+
+    "http-errors": ["http-errors@2.0.0", "", { "dependencies": { "depd": "2.0.0", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": "2.0.1", "toidentifier": "1.0.1" } }, "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ=="],
+
+    "iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-arrayish": ["is-arrayish@0.3.2", "", {}, "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
+    "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
+
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
+
+    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "load-tsconfig": ["load-tsconfig@0.2.5", "", {}, "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg=="],
+
+    "lodash.sortby": ["lodash.sortby@4.7.0", "", {}, "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="],
+
+    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@0.3.0", "", {}, "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="],
+
+    "merge-descriptors": ["merge-descriptors@1.0.3", "", {}, "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ=="],
+
+    "methods": ["methods@1.1.2", "", {}, "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="],
+
+    "mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "miniflare": ["miniflare@4.20250709.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "acorn": "8.14.0", "acorn-walk": "8.3.2", "exit-hook": "2.2.1", "glob-to-regexp": "0.4.1", "sharp": "^0.33.5", "stoppable": "1.1.0", "undici": "^5.28.5", "workerd": "1.20250709.0", "ws": "8.18.0", "youch": "4.1.0-beta.10", "zod": "3.22.3" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-dRGXi6Do9ArQZt7205QGWZ1tD6k6xQNY/mAZBAtiaQYvKxFuNyiHYlFnSN8Co4AFCVOozo/U52sVAaHvlcmnew=="],
+
+    "minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
+
+    "mlly": ["mlly@1.7.4", "", { "dependencies": { "acorn": "^8.14.0", "pathe": "^2.0.1", "pkg-types": "^1.3.0", "ufo": "^1.5.4" } }, "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
+
+    "negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "path-to-regexp": ["path-to-regexp@0.1.12", "", {}, "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
+
+    "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
+    "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
+
+    "postcss-load-config": ["postcss-load-config@6.0.1", "", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "postcss", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "qs": ["qs@6.13.0", "", { "dependencies": { "side-channel": "^1.0.6" } }, "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@2.5.2", "", { "dependencies": { "bytes": "3.1.2", "http-errors": "2.0.0", "iconv-lite": "0.4.24", "unpipe": "1.0.0" } }, "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA=="],
+
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+
+    "rollup": ["rollup@4.45.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.45.0", "@rollup/rollup-android-arm64": "4.45.0", "@rollup/rollup-darwin-arm64": "4.45.0", "@rollup/rollup-darwin-x64": "4.45.0", "@rollup/rollup-freebsd-arm64": "4.45.0", "@rollup/rollup-freebsd-x64": "4.45.0", "@rollup/rollup-linux-arm-gnueabihf": "4.45.0", "@rollup/rollup-linux-arm-musleabihf": "4.45.0", "@rollup/rollup-linux-arm64-gnu": "4.45.0", "@rollup/rollup-linux-arm64-musl": "4.45.0", "@rollup/rollup-linux-loongarch64-gnu": "4.45.0", "@rollup/rollup-linux-powerpc64le-gnu": "4.45.0", "@rollup/rollup-linux-riscv64-gnu": "4.45.0", "@rollup/rollup-linux-riscv64-musl": "4.45.0", "@rollup/rollup-linux-s390x-gnu": "4.45.0", "@rollup/rollup-linux-x64-gnu": "4.45.0", "@rollup/rollup-linux-x64-musl": "4.45.0", "@rollup/rollup-win32-arm64-msvc": "4.45.0", "@rollup/rollup-win32-ia32-msvc": "4.45.0", "@rollup/rollup-win32-x64-msvc": "4.45.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-WLjEcJRIo7i3WDDgOIJqVI2d+lAC3EwvOGy+Xfq6hs+GQuAA4Di/H72xmXkOhrIWFg2PFYSKZYfH0f4vfKXN4A=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
+    "send": ["send@0.19.0", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~1.0.2", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "0.5.2", "http-errors": "2.0.0", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "2.4.1", "range-parser": "~1.2.1", "statuses": "2.0.1" } }, "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw=="],
+
+    "serve-static": ["serve-static@1.16.2", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "0.19.0" } }, "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "sharp": ["sharp@0.33.5", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.3", "semver": "^7.6.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.33.5", "@img/sharp-darwin-x64": "0.33.5", "@img/sharp-libvips-darwin-arm64": "1.0.4", "@img/sharp-libvips-darwin-x64": "1.0.4", "@img/sharp-libvips-linux-arm": "1.0.5", "@img/sharp-libvips-linux-arm64": "1.0.4", "@img/sharp-libvips-linux-s390x": "1.0.4", "@img/sharp-libvips-linux-x64": "1.0.4", "@img/sharp-libvips-linuxmusl-arm64": "1.0.4", "@img/sharp-libvips-linuxmusl-x64": "1.0.4", "@img/sharp-linux-arm": "0.33.5", "@img/sharp-linux-arm64": "0.33.5", "@img/sharp-linux-s390x": "0.33.5", "@img/sharp-linux-x64": "0.33.5", "@img/sharp-linuxmusl-arm64": "0.33.5", "@img/sharp-linuxmusl-x64": "0.33.5", "@img/sharp-wasm32": "0.33.5", "@img/sharp-win32-ia32": "0.33.5", "@img/sharp-win32-x64": "0.33.5" } }, "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "simple-swizzle": ["simple-swizzle@0.2.2", "", { "dependencies": { "is-arrayish": "^0.3.1" } }, "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg=="],
+
+    "source-map": ["source-map@0.8.0-beta.0", "", { "dependencies": { "whatwg-url": "^7.0.0" } }, "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA=="],
+
+    "statuses": ["statuses@2.0.1", "", {}, "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="],
+
+    "stoppable": ["stoppable@1.1.0", "", {}, "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="],
+
+    "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "sucrase": ["sucrase@3.35.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "glob": "^10.3.10", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA=="],
+
+    "supports-color": ["supports-color@10.0.0", "", {}, "sha512-HRVVSbCCMbj7/kdWF9Q+bbckjBHLtHMEoJWlkmYzzdwhYMkjkOwubLM6t7NbWKjgKamGDrWL1++KrjUO1t9oAQ=="],
+
+    "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
+
+    "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
+
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "tr46": ["tr46@1.0.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA=="],
+
+    "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
+
+    "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tsup": ["tsup@8.5.0", "", { "dependencies": { "bundle-require": "^5.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "consola": "^3.4.0", "debug": "^4.4.0", "esbuild": "^0.25.0", "fix-dts-default-cjs-exports": "^1.0.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.34.8", "source-map": "0.8.0-beta.0", "sucrase": "^3.35.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.11", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core", "postcss", "typescript"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-VmBp77lWNQq6PfuMqCHD3xWl22vEoWsKajkF8t+yMBawlUS8JzEI+vOVMeuNZIuMML8qXRizFKi9oD5glKQVcQ=="],
+
+    "type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
+
+    "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "ufo": ["ufo@1.6.1", "", {}, "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="],
+
+    "undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "unenv": ["unenv@2.0.0-rc.17", "", { "dependencies": { "defu": "^6.1.4", "exsolve": "^1.0.4", "ohash": "^2.0.11", "pathe": "^2.0.3", "ufo": "^1.6.1" } }, "sha512-B06u0wXkEd+o5gOCMl/ZHl5cfpYbDZKAT+HWTL+Hws6jWu7dCiqBBXXXzMFcFVJb8D4ytAnYmxJA83uwOQRSsg=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "webidl-conversions": ["webidl-conversions@4.0.2", "", {}, "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="],
+
+    "whatwg-url": ["whatwg-url@7.1.0", "", { "dependencies": { "lodash.sortby": "^4.7.0", "tr46": "^1.0.1", "webidl-conversions": "^4.0.2" } }, "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "workerd": ["workerd@1.20250709.0", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20250709.0", "@cloudflare/workerd-darwin-arm64": "1.20250709.0", "@cloudflare/workerd-linux-64": "1.20250709.0", "@cloudflare/workerd-linux-arm64": "1.20250709.0", "@cloudflare/workerd-windows-64": "1.20250709.0" }, "bin": { "workerd": "bin/workerd" } }, "sha512-BqLPpmvRN+TYUSG61OkWamsGdEuMwgvabP8m0QOHIfofnrD2YVyWqE1kXJ0GH5EsVEuWamE5sR8XpTfsGBmIpg=="],
+
+    "wrangler": ["wrangler@4.24.3", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.0", "@cloudflare/unenv-preset": "2.3.3", "blake3-wasm": "2.1.5", "esbuild": "0.25.4", "miniflare": "4.20250709.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.17", "workerd": "1.20250709.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20250709.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-stB1Wfs5NKlspsAzz8SBujBKsDqT5lpCyrL+vSUMy3uueEtI1A5qyORbKoJhIguEbwHfWS39mBsxzm6Vm1J2cg=="],
+
+    "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
     "wsx-express-example": ["wsx-express-example@workspace:examples/express"],
 
     "wsx-hono-example": ["wsx-hono-example@workspace:examples/hono"],
 
-    "youch": [
-      "youch@4.1.0-beta.10",
-      "",
-      {
-        "dependencies": {
-          "@poppinss/colors": "^4.1.5",
-          "@poppinss/dumper": "^0.6.4",
-          "@speed-highlight/core": "^1.2.7",
-          "cookie": "^1.0.2",
-          "youch-core": "^0.3.3"
-        }
-      },
-      "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="
-    ],
+    "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
 
-    "youch-core": [
-      "youch-core@0.3.3",
-      "",
-      {
-        "dependencies": {
-          "@poppinss/exception": "^1.2.2",
-          "error-stack-parser-es": "^1.0.5"
-        }
-      },
-      "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="
-    ],
+    "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
 
-    "zod": [
-      "zod@3.22.3",
-      "",
-      {},
-      "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug=="
-    ],
+    "zod": ["zod@3.22.3", "", {}, "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug=="],
 
-    "@cloudflare/kv-asset-handler/mime": [
-      "mime@3.0.0",
-      "",
-      { "bin": { "mime": "cli.js" } },
-      "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="
-    ],
+    "@cloudflare/kv-asset-handler/mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
 
-    "@cspotcode/source-map-support/@jridgewell/trace-mapping": [
-      "@jridgewell/trace-mapping@0.3.9",
-      "",
-      {
-        "dependencies": {
-          "@jridgewell/resolve-uri": "^3.0.3",
-          "@jridgewell/sourcemap-codec": "^1.4.10"
-        }
-      },
-      "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="
-    ],
+    "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
-    "body-parser/debug": [
-      "debug@2.6.9",
-      "",
-      { "dependencies": { "ms": "2.0.0" } },
-      "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
-    ],
+    "body-parser/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
-    "express/debug": [
-      "debug@2.6.9",
-      "",
-      { "dependencies": { "ms": "2.0.0" } },
-      "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
-    ],
+    "express/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
-    "finalhandler/debug": [
-      "debug@2.6.9",
-      "",
-      { "dependencies": { "ms": "2.0.0" } },
-      "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
-    ],
+    "finalhandler/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
-    "send/debug": [
-      "debug@2.6.9",
-      "",
-      { "dependencies": { "ms": "2.0.0" } },
-      "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
-    ],
+    "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
-    "send/encodeurl": [
-      "encodeurl@1.0.2",
-      "",
-      {},
-      "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
-    ],
+    "send/encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
 
-    "string-width-cjs/emoji-regex": [
-      "emoji-regex@8.0.0",
-      "",
-      {},
-      "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    ],
+    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
-    "string-width-cjs/strip-ansi": [
-      "strip-ansi@6.0.1",
-      "",
-      { "dependencies": { "ansi-regex": "^5.0.1" } },
-      "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="
-    ],
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "strip-ansi-cjs/ansi-regex": [
-      "ansi-regex@5.0.1",
-      "",
-      {},
-      "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-    ],
+    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "wrangler/path-to-regexp": [
-      "path-to-regexp@6.3.0",
-      "",
-      {},
-      "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="
-    ],
+    "wrangler/path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
-    "wrap-ansi-cjs/ansi-styles": [
-      "ansi-styles@4.3.0",
-      "",
-      { "dependencies": { "color-convert": "^2.0.1" } },
-      "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="
-    ],
+    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
-    "wrap-ansi-cjs/string-width": [
-      "string-width@4.2.3",
-      "",
-      {
-        "dependencies": {
-          "emoji-regex": "^8.0.0",
-          "is-fullwidth-code-point": "^3.0.0",
-          "strip-ansi": "^6.0.1"
-        }
-      },
-      "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="
-    ],
+    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
-    "wrap-ansi-cjs/strip-ansi": [
-      "strip-ansi@6.0.1",
-      "",
-      { "dependencies": { "ansi-regex": "^5.0.1" } },
-      "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="
-    ],
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "youch/cookie": [
-      "cookie@1.0.2",
-      "",
-      {},
-      "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA=="
-    ],
+    "youch/cookie": ["cookie@1.0.2", "", {}, "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA=="],
 
-    "body-parser/debug/ms": [
-      "ms@2.0.0",
-      "",
-      {},
-      "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    ],
+    "body-parser/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
-    "express/debug/ms": [
-      "ms@2.0.0",
-      "",
-      {},
-      "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    ],
+    "express/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
-    "finalhandler/debug/ms": [
-      "ms@2.0.0",
-      "",
-      {},
-      "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    ],
+    "finalhandler/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
-    "send/debug/ms": [
-      "ms@2.0.0",
-      "",
-      {},
-      "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    ],
+    "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
-    "string-width-cjs/strip-ansi/ansi-regex": [
-      "ansi-regex@5.0.1",
-      "",
-      {},
-      "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-    ],
+    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "wrap-ansi-cjs/string-width/emoji-regex": [
-      "emoji-regex@8.0.0",
-      "",
-      {},
-      "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    ],
+    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
-    "wrap-ansi-cjs/strip-ansi/ansi-regex": [
-      "ansi-regex@5.0.1",
-      "",
-      {},
-      "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-    ]
+    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }
 }

--- a/examples/express/public/wsx.js
+++ b/examples/express/public/wsx.js
@@ -30,6 +30,35 @@
  * @property {HTMLElement} [element] - Source element
  */
 
+/**
+ * @typedef {Object} WSXStreamOptions
+ * @property {string} [id] - Optional stream identifier
+ * @property {Object} [metadata] - Additional metadata to include with the stream
+ */
+
+/**
+ * @typedef {Object} WSXJSONOptions
+ * @property {string} [id] - Optional JSON message identifier
+ * @property {Object} [metadata] - Additional metadata to include with the message
+ */
+
+/**
+ * @typedef {Object} WSXJSONDetail
+ * @property {string} id - Message identifier
+ * @property {string} channel - Channel the JSON message was published to
+ * @property {Object} metadata - Optional metadata provided by the sender
+ * @property {*} data - The JSON payload
+ */
+
+/**
+ * @typedef {Object} WSXStreamDetail
+ * @property {string} id - Stream identifier
+ * @property {string} channel - Logical channel for the stream
+ * @property {Object} metadata - Metadata provided by the sender
+ * @property {Uint8Array} data - Raw binary payload
+ * @property {ArrayBuffer} arrayBuffer - Copy of the payload as an ArrayBuffer
+ */
+
 class WSX {
   /**
    * @param {WSXConfig} config - Configuration object
@@ -42,14 +71,18 @@ class WSX {
     this.requestCounter = 0;
     this.throttleTimers = new Map();
     this.debounceTimers = new Map();
-    
+    this.streamHandlers = new Map();
+    this.jsonHandlers = new Map();
+    this.textEncoder = new TextEncoder();
+    this.textDecoder = new TextDecoder();
+
     this.config = {
       reconnectInterval: 3000,
       maxReconnectAttempts: 5,
       debug: false,
-      ...config
+      ...config,
     };
-    
+
     this.connect();
     this.setupEventListeners();
   }
@@ -57,12 +90,13 @@ class WSX {
   connect() {
     try {
       this.ws = new WebSocket(this.config.url);
+      this.ws.binaryType = "arraybuffer";
       this.ws.onopen = this.onOpen.bind(this);
       this.ws.onmessage = this.onMessage.bind(this);
       this.ws.onclose = this.onClose.bind(this);
       this.ws.onerror = this.onError.bind(this);
     } catch (error) {
-      this.log('Connection failed:', error);
+      this.log("Connection failed:", error);
       this.scheduleReconnect();
     }
   }
@@ -70,57 +104,504 @@ class WSX {
   onOpen() {
     this.isConnected = true;
     this.reconnectAttempts = 0;
-    this.log('Connected to WSX server');
-    
+    this.log("Connected to WSX server");
+
     // Trigger connection event
-    document.dispatchEvent(new CustomEvent('wsx:connected'));
+    document.dispatchEvent(new CustomEvent("wsx:connected"));
   }
 
-  onMessage(event) {
+  async onMessage(event) {
     try {
-      const message = JSON.parse(event.data);
-      this.handleMessage(message);
+      if (typeof event.data === "string") {
+        const message = JSON.parse(event.data);
+        this.handleMessage(message);
+      } else {
+        await this.handleBinaryMessage(event.data);
+      }
     } catch (error) {
-      this.log('Error parsing message:', error);
+      this.log("Error processing message:", error);
     }
+  }
+
+  async handleBinaryMessage(data) {
+    try {
+      const bytes = await this.toUint8Array(data);
+
+      if (bytes.byteLength < 4) {
+        throw new Error("Stream message too small");
+      }
+
+      const view = new DataView(
+        bytes.buffer,
+        bytes.byteOffset,
+        bytes.byteLength
+      );
+      const headerLength = view.getUint32(0, false);
+      const headerStart = 4;
+      const headerEnd = headerStart + headerLength;
+
+      if (bytes.byteLength < headerEnd) {
+        throw new Error("Stream message header incomplete");
+      }
+
+      const headerBytes = bytes.subarray(headerStart, headerEnd);
+      const headerString = this.textDecoder.decode(headerBytes);
+      const header = JSON.parse(headerString);
+
+      if (!header || header.type !== "stream") {
+        this.log("Unsupported binary message received", header);
+        return;
+      }
+
+      if (typeof header.id !== "string" || typeof header.channel !== "string") {
+        throw new Error("Invalid stream header");
+      }
+
+      const payload = bytes.subarray(headerEnd);
+
+      this.dispatchStream(
+        {
+          id: header.id,
+          channel: header.channel,
+          metadata: header.metadata || {},
+        },
+        payload
+      );
+    } catch (error) {
+      this.log("Error handling binary message:", error);
+    }
+  }
+
+  /**
+   * Dispatch an incoming JSON message to registered handlers and DOM listeners.
+   * @param {{id?: string, channel: string, metadata?: Object, data: any, type?: string}} message
+   */
+  dispatchJson(message) {
+    if (!message || typeof message.channel !== "string") {
+      this.log("Invalid JSON message received", message);
+      return;
+    }
+
+    const detail = {
+      id:
+        typeof message.id === "string"
+          ? message.id
+          : this.generateJsonId(),
+      channel: message.channel,
+      metadata:
+        message.metadata && typeof message.metadata === "object"
+          ? message.metadata
+          : {},
+      data: message.data,
+    };
+
+    const handler =
+      this.jsonHandlers.get(detail.channel) || this.jsonHandlers.get("");
+
+    if (handler) {
+      try {
+        handler(detail);
+      } catch (error) {
+        this.log("Error in JSON handler:", error);
+      }
+    }
+
+    document.dispatchEvent(new CustomEvent("wsx:json", { detail }));
+  }
+
+  /**
+   * Dispatch a decoded stream payload to registered handlers and DOM listeners.
+   * @param {{id: string, channel: string, metadata: Object}} message - Stream metadata
+   * @param {Uint8Array} payload - Binary payload for the stream message
+   */
+  dispatchStream(message, payload) {
+    const detail = {
+      id: message.id,
+      channel: message.channel,
+      metadata: message.metadata || {},
+      data: payload,
+      arrayBuffer: payload.buffer.slice(
+        payload.byteOffset,
+        payload.byteOffset + payload.byteLength
+      ),
+    };
+
+    const handler =
+      this.streamHandlers.get(message.channel) ||
+      this.streamHandlers.get("");
+
+    if (handler) {
+      try {
+        handler(detail);
+      } catch (error) {
+        this.log("Error in stream handler:", error);
+      }
+    }
+
+    document.dispatchEvent(new CustomEvent("wsx:stream", { detail }));
+  }
+
+  /**
+   * Register a handler for incoming stream data.
+   * @param {string|function} channelOrHandler - Channel name or catch-all handler
+   * @param {function} [handler] - Handler invoked when the specified channel receives data
+   * @returns {WSX} The WSX instance for chaining
+   */
+  onJson(channelOrHandler, handler) {
+    if (typeof channelOrHandler === "string") {
+      if (typeof handler !== "function") {
+        throw new Error("JSON handler must be a function");
+      }
+      this.jsonHandlers.set(channelOrHandler, handler);
+    } else if (typeof channelOrHandler === "function") {
+      this.jsonHandlers.set("", channelOrHandler);
+    } else {
+      throw new Error("Invalid JSON handler registration");
+    }
+
+    return this;
+  }
+
+  /**
+   * Remove a previously registered JSON handler.
+   * @param {string} [channel] - Channel to remove; omitting clears all handlers
+   * @returns {WSX} The WSX instance for chaining
+   */
+  offJson(channel) {
+    if (typeof channel === "string") {
+      this.jsonHandlers.delete(channel);
+    } else {
+      this.jsonHandlers.clear();
+    }
+
+    return this;
+  }
+
+  /**
+   * Register a handler for incoming stream data.
+   * @param {string|function} channelOrHandler - Channel name or catch-all handler
+   * @param {function} [handler] - Handler invoked when the specified channel receives data
+   * @returns {WSX} The WSX instance for chaining
+   */
+  onStream(channelOrHandler, handler) {
+    if (typeof channelOrHandler === "string") {
+      if (typeof handler !== "function") {
+        throw new Error("Stream handler must be a function");
+      }
+      this.streamHandlers.set(channelOrHandler, handler);
+    } else if (typeof channelOrHandler === "function") {
+      this.streamHandlers.set("", channelOrHandler);
+    } else {
+      throw new Error("Invalid stream handler registration");
+    }
+
+    return this;
+  }
+
+  /**
+   * Remove a previously registered stream handler.
+   * @param {string} [channel] - Channel to remove; omitting clears all handlers
+   * @returns {WSX} The WSX instance for chaining
+   */
+  offStream(channel) {
+    if (typeof channel === "string") {
+      this.streamHandlers.delete(channel);
+    } else {
+      this.streamHandlers.clear();
+    }
+
+    return this;
+  }
+
+  generateStreamId() {
+    return `stream_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+  }
+
+  generateJsonId() {
+    return `json_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+  }
+
+  /**
+   * Send a binary stream payload to the server.
+   * @param {string} channel - Logical channel name used by server handlers
+   * @param {ArrayBuffer|ArrayBufferView|Blob} data - Binary payload to transmit
+   * @param {WSXStreamOptions} [options] - Additional stream options
+   * @returns {Promise<string>} Resolves with the stream identifier
+   */
+  async sendStream(channel, data, options = {}) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new Error("Cannot send stream: connection is not open");
+    }
+
+    const streamId = options.id || this.generateStreamId();
+    const header = {
+      type: "stream",
+      id: streamId,
+      channel,
+    };
+
+    if (options.metadata !== undefined) {
+      header.metadata = options.metadata;
+    }
+
+    const headerBytes = this.textEncoder.encode(JSON.stringify(header));
+    const headerLengthBuffer = new ArrayBuffer(4);
+    new DataView(headerLengthBuffer).setUint32(
+      0,
+      headerBytes.byteLength,
+      false
+    );
+    const headerLengthBytes = new Uint8Array(headerLengthBuffer);
+    const payloadBytes = await this.toUint8Array(data);
+    const frame = new Uint8Array(
+      4 + headerBytes.byteLength + payloadBytes.byteLength
+    );
+    frame.set(headerLengthBytes, 0);
+    frame.set(headerBytes, 4);
+    frame.set(payloadBytes, 4 + headerBytes.byteLength);
+
+    this.ws.send(frame);
+
+    return streamId;
+  }
+
+  /**
+   * Send a JSON message payload to the server.
+   * @param {string} channel - Logical channel name used by server handlers
+   * @param {*} data - JSON-serializable payload to transmit
+   * @param {WSXJSONOptions} [options] - Additional message options
+   * @returns {string} Identifier of the sent JSON message
+   */
+  sendJson(channel, data, options = {}) {
+    if (this.demoMode) {
+      throw new Error("Cannot send JSON messages while demo mode is active");
+    }
+
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new Error("Cannot send JSON message: connection is not open");
+    }
+
+    const message = {
+      type: "json",
+      id: options.id || this.generateJsonId(),
+      channel,
+      data,
+    };
+
+    if (options.metadata !== undefined) {
+      message.metadata = options.metadata;
+    }
+
+    this.send(message);
+
+    return message.id;
+  }
+
+  /**
+   * Normalise a variety of binary inputs into a Uint8Array view.
+   * @param {ArrayBuffer|ArrayBufferView|Blob} data - Incoming binary data
+   * @returns {Promise<Uint8Array>} View of the provided binary data
+   */
+  async toUint8Array(data) {
+    if (data instanceof ArrayBuffer) {
+      return new Uint8Array(data);
+    }
+
+    if (ArrayBuffer.isView(data)) {
+      return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+    }
+
+    if (typeof Blob !== "undefined" && data instanceof Blob) {
+      const buffer = await data.arrayBuffer();
+      return new Uint8Array(buffer);
+    }
+
+    throw new Error("Unsupported binary data type");
   }
 
   onClose() {
     this.isConnected = false;
-    this.log('Disconnected from WSX server');
-    
+    this.log("Disconnected from WSX server");
+
     // Trigger disconnection event
-    document.dispatchEvent(new CustomEvent('wsx:disconnected'));
-    
+    document.dispatchEvent(new CustomEvent("wsx:disconnected"));
+
     if (this.reconnectAttempts < this.config.maxReconnectAttempts) {
       this.scheduleReconnect();
     }
   }
 
   onError(error) {
-    this.log('WebSocket error:', error);
+    this.log("WebSocket error:", error);
+    // Enable demo mode if connection fails
+    this.enableDemoMode();
   }
 
   scheduleReconnect() {
+    if (this.reconnectAttempts >= this.config.maxReconnectAttempts) {
+      this.log("Max reconnect attempts reached, enabling demo mode");
+      this.enableDemoMode();
+      return;
+    }
+
     setTimeout(() => {
       this.reconnectAttempts++;
-      this.log(`Reconnection attempt ${this.reconnectAttempts}/${this.config.maxReconnectAttempts}`);
+      this.log(
+        `Reconnection attempt ${this.reconnectAttempts}/${this.config.maxReconnectAttempts}`
+      );
       this.connect();
     }, this.config.reconnectInterval);
   }
 
+  enableDemoMode() {
+    this.demoMode = true;
+    this.isConnected = true; // Simulate connection for demo
+    this.log("Demo mode enabled - simulating WebSocket responses");
+
+    // Update live indicator
+    const liveStats = document.getElementById("live-stats");
+    if (liveStats) {
+      liveStats.innerHTML = `
+        <span class="live-dot"></span>
+        Demo Mode (WebSocket simulation)
+      `;
+    }
+  }
+
+  generateDemoResponse(request) {
+    const responses = {
+      "animate-hero": {
+        id: request.id,
+        target: request.target,
+        html: `<div class="glitch-text">🚀 WSX: HYPERMEDIA GOES REAL-TIME 🚀</div>`,
+      },
+      "show-feature": {
+        id: request.id,
+        target: request.target,
+        html: this.generateFeatureShowcase(request.data?.feature || "realtime"),
+      },
+      "demo-interaction": {
+        id: request.id,
+        target: request.target,
+        html: `<div class="demo-response pulse">🎉 WSX Magic Happened! 🎉</div>`,
+      },
+      "get-stats": {
+        id: request.id,
+        target: request.target,
+        html: `
+          <div class="stats-grid animate-fade-in">
+            <div class="stat-item">
+              <div class="stat-number neon-text">1</div>
+              <div class="stat-label">Demo Connections</div>
+            </div>
+            <div class="stat-item">
+              <div class="stat-number neon-text">${Math.floor(
+                Math.random() * 10000
+              ).toLocaleString()}</div>
+              <div class="stat-label">DOM Updates</div>
+            </div>
+            <div class="stat-item">
+              <div class="stat-number neon-text">3</div>
+              <div class="stat-label">Frameworks</div>
+            </div>
+            <div class="stat-item">
+              <div class="stat-number neon-text">v1.0.0</div>
+              <div class="stat-label">Version</div>
+            </div>
+          </div>
+        `,
+      },
+    };
+
+    return (
+      responses[request.handler] || {
+        id: request.id,
+        target: request.target,
+        html: `<div class="demo-response">Demo response for: ${request.handler}</div>`,
+      }
+    );
+  }
+
+  generateFeatureShowcase(feature) {
+    const features = {
+      realtime: {
+        icon: "⚡",
+        title: "Real-Time Hypermedia",
+        description: "HTMX-style patterns with WebSocket power",
+        code: `wsx.on("update", async (req, conn) => {
+  return {
+    target: "#content",
+    html: \`<div class="live">\${data}</div>\`
+  };
+});`,
+      },
+      oob: {
+        icon: "🎯",
+        title: "Out-of-Band Updates",
+        description: "Update multiple DOM elements simultaneously",
+        code: `return {
+  target: "#main",
+  html: \`<div>Main content</div>\`,
+  oob: [{
+    target: "#sidebar",
+    html: \`<div>Sidebar update</div>\`
+  }]
+};`,
+      },
+      triggers: {
+        icon: "🎮",
+        title: "Advanced Triggers",
+        description: "Rich trigger system with debouncing and conditions",
+        code: `<input 
+  wx-send="search"
+  wx-trigger="keyup delay:300ms"
+  wx-target="#results"
+/>`,
+      },
+      framework: {
+        icon: "🔧",
+        title: "Framework Agnostic",
+        description: "Works with Express, Hono, and custom adapters",
+        code: `import { createHonoWSXServer } from "@wsx-sh/hono";
+import { createExpressWSXServer } from "@wsx-sh/express";
+
+const wsx = createHonoWSXServer();`,
+      },
+    };
+
+    const featureData = features[feature] || features.realtime;
+
+    return `
+      <div class="feature-showcase animate-in">
+        <div class="feature-icon">${featureData.icon}</div>
+        <h3 class="neon-text">${featureData.title}</h3>
+        <p class="feature-description">${featureData.description}</p>
+        <pre class="code-block"><code>${featureData.code}</code></pre>
+        <div class="feature-glow"></div>
+      </div>
+    `;
+  }
+
   handleMessage(message) {
+    if (message && typeof message === "object" && message.type === "json") {
+      this.dispatchJson(message);
+      return;
+    }
+
     // Handle main response
-    this.processSwapUpdate({
-      target: message.target,
-      html: message.html,
-      swap: message.swap || 'innerHTML'
-    }, message);
+    this.processSwapUpdate(
+      {
+        target: message.target,
+        html: message.html,
+        swap: message.swap || "innerHTML",
+      },
+      message
+    );
 
     // Handle out-of-band swaps
     if (message.oob && Array.isArray(message.oob)) {
-      message.oob.forEach(oobUpdate => {
-        this.log('Processing OOB update:', oobUpdate);
+      message.oob.forEach((oobUpdate) => {
+        this.log("Processing OOB update:", oobUpdate);
         this.processSwapUpdate(oobUpdate, message, true);
       });
     }
@@ -137,29 +618,31 @@ class WSX {
    */
   processSwapUpdate(update, message, isOOB = false) {
     const targetElement = document.querySelector(update.target);
-    
+
     if (!targetElement) {
-      this.log(`Target element not found: ${update.target}${isOOB ? ' (OOB)' : ''}`);
+      this.log(
+        `Target element not found: ${update.target}${isOOB ? " (OOB)" : ""}`
+      );
       return;
     }
 
-    const swap = update.swap || 'innerHTML';
+    const swap = update.swap || "innerHTML";
     const swapSpec = this.parseSwapSpec(swap);
-    
+
     // Trigger before swap event
-    const beforeEvent = new CustomEvent('wsx:beforeSwap', {
-      detail: { 
-        message, 
-        element: targetElement, 
+    const beforeEvent = new CustomEvent("wsx:beforeSwap", {
+      detail: {
+        message,
+        element: targetElement,
         update,
-        isOOB 
-      }
+        isOOB,
+      },
     });
     targetElement.dispatchEvent(beforeEvent);
 
     // Apply swap delay if specified
     const delay = swapSpec.swap || 0;
-    
+
     setTimeout(() => {
       // Perform the swap
       this.performSwap(targetElement, update.html, swapSpec);
@@ -167,13 +650,13 @@ class WSX {
       // Apply settle delay and trigger after swap event
       const settleDelay = swapSpec.settle || 20;
       setTimeout(() => {
-        const afterEvent = new CustomEvent('wsx:afterSwap', {
-          detail: { 
-            message, 
-            element: targetElement, 
+        const afterEvent = new CustomEvent("wsx:afterSwap", {
+          detail: {
+            message,
+            element: targetElement,
             update,
-            isOOB 
-          }
+            isOOB,
+          },
         });
         targetElement.dispatchEvent(afterEvent);
 
@@ -182,36 +665,35 @@ class WSX {
           this.handleShowScroll(targetElement, swapSpec);
         }
       }, settleDelay);
-
     }, delay);
   }
 
   performSwap(element, html, swapSpec) {
-    const swapStyle = swapSpec.style || 'innerHTML';
-    
+    const swapStyle = swapSpec.style || "innerHTML";
+
     switch (swapStyle) {
-      case 'innerHTML':
+      case "innerHTML":
         element.innerHTML = html;
         break;
-      case 'outerHTML':
+      case "outerHTML":
         element.outerHTML = html;
         break;
-      case 'beforebegin':
-        element.insertAdjacentHTML('beforebegin', html);
+      case "beforebegin":
+        element.insertAdjacentHTML("beforebegin", html);
         break;
-      case 'afterbegin':
-        element.insertAdjacentHTML('afterbegin', html);
+      case "afterbegin":
+        element.insertAdjacentHTML("afterbegin", html);
         break;
-      case 'beforeend':
-        element.insertAdjacentHTML('beforeend', html);
+      case "beforeend":
+        element.insertAdjacentHTML("beforeend", html);
         break;
-      case 'afterend':
-        element.insertAdjacentHTML('afterend', html);
+      case "afterend":
+        element.insertAdjacentHTML("afterend", html);
         break;
-      case 'delete':
+      case "delete":
         element.remove();
         break;
-      case 'none':
+      case "none":
         // Do nothing - useful for side effects only
         break;
       default:
@@ -226,43 +708,43 @@ class WSX {
    */
   parseSwapSpec(swapString) {
     const spec = {
-      style: 'innerHTML',
+      style: "innerHTML",
       swap: 0,
       settle: 20,
       show: null,
       scroll: null,
-      focus: false
+      focus: false,
     };
 
     if (!swapString) return spec;
 
     const parts = swapString.trim().split(/\s+/);
-    
+
     // First part is the swap style if it doesn't contain ':'
-    if (parts[0] && !parts[0].includes(':')) {
+    if (parts[0] && !parts[0].includes(":")) {
       spec.style = parts[0];
       parts.shift();
     }
 
     // Parse modifiers
-    parts.forEach(part => {
-      const [key, value] = part.split(':');
-      
+    parts.forEach((part) => {
+      const [key, value] = part.split(":");
+
       switch (key) {
-        case 'swap':
+        case "swap":
           spec.swap = this.parseTime(value);
           break;
-        case 'settle':
+        case "settle":
           spec.settle = this.parseTime(value);
           break;
-        case 'show':
-          spec.show = value || 'top';
+        case "show":
+          spec.show = value || "top";
           break;
-        case 'scroll':
-          spec.scroll = value || 'top';
+        case "scroll":
+          spec.scroll = value || "top";
           break;
-        case 'focus-scroll':
-          spec.focus = value !== 'false';
+        case "focus-scroll":
+          spec.focus = value !== "false";
           break;
       }
     });
@@ -277,14 +759,14 @@ class WSX {
    */
   parseTime(timeStr) {
     if (!timeStr) return 0;
-    
+
     const match = timeStr.match(/^(\d+(?:\.\d+)?)(ms|s)?$/);
     if (!match) return 0;
-    
+
     const value = parseFloat(match[1]);
-    const unit = match[2] || 'ms';
-    
-    return unit === 's' ? value * 1000 : value;
+    const unit = match[2] || "ms";
+
+    return unit === "s" ? value * 1000 : value;
   }
 
   /**
@@ -294,9 +776,10 @@ class WSX {
    */
   handleShowScroll(element, swapSpec) {
     if (swapSpec.show || swapSpec.scroll) {
-      const targetEl = swapSpec.show === 'window' || swapSpec.scroll === 'window' 
-        ? window 
-        : element;
+      const targetEl =
+        swapSpec.show === "window" || swapSpec.scroll === "window"
+          ? window
+          : element;
 
       if (swapSpec.show) {
         this.scrollIntoView(targetEl, swapSpec.show);
@@ -313,25 +796,25 @@ class WSX {
    */
   scrollIntoView(target, position) {
     if (target === window) {
-      const scrollPos = position === 'bottom' ? document.body.scrollHeight : 0;
-      window.scrollTo({ top: scrollPos, behavior: 'smooth' });
+      const scrollPos = position === "bottom" ? document.body.scrollHeight : 0;
+      window.scrollTo({ top: scrollPos, behavior: "smooth" });
       return;
     }
 
-    const options = { behavior: 'smooth' };
-    
+    const options = { behavior: "smooth" };
+
     switch (position) {
-      case 'top':
-        options.block = 'start';
+      case "top":
+        options.block = "start";
         break;
-      case 'bottom':
-        options.block = 'end';
+      case "bottom":
+        options.block = "end";
         break;
-      case 'center':
-        options.block = 'center';
+      case "center":
+        options.block = "center";
         break;
       default:
-        options.block = 'nearest';
+        options.block = "nearest";
     }
 
     target.scrollIntoView(options);
@@ -339,35 +822,48 @@ class WSX {
 
   setupEventListeners() {
     // Common events to listen for
-    const events = ['click', 'submit', 'input', 'change', 'keyup', 'keydown', 'focus', 'blur', 'load', 'scroll', 'mouseover', 'mouseout'];
-    
-    events.forEach(eventType => {
+    const events = [
+      "click",
+      "submit",
+      "input",
+      "change",
+      "keyup",
+      "keydown",
+      "focus",
+      "blur",
+      "load",
+      "scroll",
+      "mouseover",
+      "mouseout",
+    ];
+
+    events.forEach((eventType) => {
       document.addEventListener(eventType, (e) => {
         this.handleEvent(e, eventType);
       });
     });
 
     // Handle intersect events (for lazy loading)
-    if ('IntersectionObserver' in window) {
+    if ("IntersectionObserver" in window) {
       this.setupIntersectionObserver();
     }
   }
 
   handleEvent(e, eventType) {
     let element = e.target;
-    
+
     // Walk up the DOM tree to find elements with wx-send
     while (element && element !== document) {
-      if (element.hasAttribute && element.hasAttribute('wx-send')) {
-        const triggerSpec = element.getAttribute('wx-trigger') || eventType;
+      if (element.hasAttribute && element.hasAttribute("wx-send")) {
+        const triggerSpec = element.getAttribute("wx-trigger") || eventType;
         const triggers = this.parseTriggerSpec(triggerSpec);
-        
+
         for (const trigger of triggers) {
           if (this.shouldTrigger(trigger, e, eventType, element)) {
-            if (eventType === 'submit') {
+            if (eventType === "submit") {
               e.preventDefault();
             }
-            
+
             this.processTrigger(element, trigger, e);
             break; // Only process the first matching trigger
           }
@@ -383,54 +879,54 @@ class WSX {
    * @returns {Array} Array of parsed trigger objects
    */
   parseTriggerSpec(triggerSpec) {
-    if (!triggerSpec) return [{ event: 'click' }];
-    
-    return triggerSpec.split(',').map(spec => {
-      const trigger = { event: 'click', modifiers: {} };
+    if (!triggerSpec) return [{ event: "click" }];
+
+    return triggerSpec.split(",").map((spec) => {
+      const trigger = { event: "click", modifiers: {} };
       const parts = spec.trim().split(/\s+/);
-      
+
       // Parse event name and conditions
       const eventPart = parts[0];
       const conditionMatch = eventPart.match(/^(\w+)(?:\[([^\]]+)\])?$/);
-      
+
       if (conditionMatch) {
         trigger.event = conditionMatch[1];
         if (conditionMatch[2]) {
           trigger.condition = conditionMatch[2];
         }
       }
-      
+
       // Parse modifiers
-      parts.slice(1).forEach(part => {
-        const [key, value] = part.split(':');
+      parts.slice(1).forEach((part) => {
+        const [key, value] = part.split(":");
         switch (key) {
-          case 'once':
+          case "once":
             trigger.modifiers.once = true;
             break;
-          case 'changed':
+          case "changed":
             trigger.modifiers.changed = true;
             break;
-          case 'delay':
+          case "delay":
             trigger.modifiers.delay = this.parseTime(value);
             break;
-          case 'throttle':
+          case "throttle":
             trigger.modifiers.throttle = this.parseTime(value);
             break;
-          case 'from':
+          case "from":
             trigger.modifiers.from = value;
             break;
-          case 'target':
+          case "target":
             trigger.modifiers.target = value;
             break;
-          case 'consume':
+          case "consume":
             trigger.modifiers.consume = true;
             break;
-          case 'queue':
-            trigger.modifiers.queue = value || 'last';
+          case "queue":
+            trigger.modifiers.queue = value || "last";
             break;
         }
       });
-      
+
       return trigger;
     });
   }
@@ -441,47 +937,50 @@ class WSX {
   shouldTrigger(trigger, event, eventType, element) {
     // Check if event type matches
     if (trigger.event !== eventType) return false;
-    
+
     // Check condition (e.g., ctrlKey, shiftKey, etc.)
     if (trigger.condition) {
       try {
         // Simple condition evaluation for common cases
-        if (trigger.condition.includes('ctrlKey') && !event.ctrlKey) return false;
-        if (trigger.condition.includes('shiftKey') && !event.shiftKey) return false;
-        if (trigger.condition.includes('altKey') && !event.altKey) return false;
-        if (trigger.condition.includes('metaKey') && !event.metaKey) return false;
-        
+        if (trigger.condition.includes("ctrlKey") && !event.ctrlKey)
+          return false;
+        if (trigger.condition.includes("shiftKey") && !event.shiftKey)
+          return false;
+        if (trigger.condition.includes("altKey") && !event.altKey) return false;
+        if (trigger.condition.includes("metaKey") && !event.metaKey)
+          return false;
+
         // Handle key conditions like "keyup[Enter]"
         const keyMatch = trigger.condition.match(/^(\w+)$/);
         if (keyMatch && event.key !== keyMatch[1]) return false;
       } catch (e) {
-        this.log('Error evaluating trigger condition:', e);
+        this.log("Error evaluating trigger condition:", e);
         return false;
       }
     }
-    
+
     // Check 'from' modifier (event delegation)
     if (trigger.modifiers.from) {
       const fromElement = document.querySelector(trigger.modifiers.from);
       if (!fromElement || !fromElement.contains(event.target)) return false;
     }
-    
+
     // Check 'target' modifier
     if (trigger.modifiers.target) {
       if (!event.target.matches(trigger.modifiers.target)) return false;
     }
-    
+
     // Check 'changed' modifier for form inputs
     if (trigger.modifiers.changed && element.tagName) {
       const tagName = element.tagName.toLowerCase();
-      if (['input', 'textarea', 'select'].includes(tagName)) {
+      if (["input", "textarea", "select"].includes(tagName)) {
         const currentValue = element.value;
         const lastValue = element.dataset.wsxLastValue;
         if (currentValue === lastValue) return false;
         element.dataset.wsxLastValue = currentValue;
       }
     }
-    
+
     return true;
   }
 
@@ -489,59 +988,63 @@ class WSX {
    * Process trigger with modifiers like delay, throttle, etc.
    */
   processTrigger(element, trigger, event) {
-    const elementId = element.id || `wsx_${Math.random().toString(36).substr(2, 9)}`;
+    const elementId =
+      element.id || `wsx_${Math.random().toString(36).substr(2, 9)}`;
     if (!element.id) element.id = elementId;
-    
+
     // Handle 'once' modifier
     if (trigger.modifiers.once) {
       if (element.dataset.wsxTriggered) return;
-      element.dataset.wsxTriggered = 'true';
+      element.dataset.wsxTriggered = "true";
     }
-    
+
     // Handle 'consume' modifier
     if (trigger.modifiers.consume) {
       event.stopPropagation();
     }
-    
+
     const executeRequest = () => {
       this.handleTrigger(element, trigger.event, event);
     };
-    
+
     // Handle 'delay' modifier
     if (trigger.modifiers.delay) {
       setTimeout(executeRequest, trigger.modifiers.delay);
       return;
     }
-    
+
     // Handle 'throttle' modifier
     if (trigger.modifiers.throttle) {
       const throttleKey = `${elementId}_${trigger.event}`;
       if (this.throttleTimers.has(throttleKey)) return;
-      
+
       executeRequest();
-      this.throttleTimers.set(throttleKey, setTimeout(() => {
-        this.throttleTimers.delete(throttleKey);
-      }, trigger.modifiers.throttle));
+      this.throttleTimers.set(
+        throttleKey,
+        setTimeout(() => {
+          this.throttleTimers.delete(throttleKey);
+        }, trigger.modifiers.throttle)
+      );
       return;
     }
-    
+
     // Handle 'queue' modifier with debouncing
     if (trigger.modifiers.queue) {
       const debounceKey = `${elementId}_${trigger.event}`;
-      
+
       if (this.debounceTimers.has(debounceKey)) {
         clearTimeout(this.debounceTimers.get(debounceKey));
       }
-      
+
       const timer = setTimeout(() => {
         this.debounceTimers.delete(debounceKey);
         executeRequest();
       }, 300); // Default debounce time
-      
+
       this.debounceTimers.set(debounceKey, timer);
       return;
     }
-    
+
     // Execute immediately
     executeRequest();
   }
@@ -551,17 +1054,17 @@ class WSX {
    */
   setupIntersectionObserver() {
     const observer = new IntersectionObserver((entries) => {
-      entries.forEach(entry => {
+      entries.forEach((entry) => {
         if (entry.isIntersecting) {
           const element = entry.target;
-          this.handleTrigger(element, 'intersect');
+          this.handleTrigger(element, "intersect");
         }
       });
     });
-    
+
     // Observe elements with intersect triggers
-    document.addEventListener('DOMContentLoaded', () => {
-      document.querySelectorAll('[wx-trigger*="intersect"]').forEach(el => {
+    document.addEventListener("DOMContentLoaded", () => {
+      document.querySelectorAll('[wx-trigger*="intersect"]').forEach((el) => {
         observer.observe(el);
       });
     });
@@ -569,34 +1072,46 @@ class WSX {
 
   handleTrigger(element, eventType, event) {
     if (!this.isConnected) {
-      this.log('Not connected to server');
+      this.log("Not connected to server");
       return;
     }
 
-    const handler = element.getAttribute('wx-send') || '';
-    const target = element.getAttribute('wx-target') || 'body';
-    const swap = element.getAttribute('wx-swap') || 'innerHTML';
-    const trigger = element.getAttribute('wx-trigger') || eventType;
+    const handler = element.getAttribute("wx-send") || "";
+    const target = element.getAttribute("wx-target") || "body";
+    const swap = element.getAttribute("wx-swap") || "innerHTML";
+    const trigger = element.getAttribute("wx-trigger") || eventType;
 
     // Collect form data if it's a form element
     let data = {};
-    
-    if (element.tagName === 'FORM') {
+
+    if (element.tagName === "FORM") {
       const formData = new FormData(element);
       data = Object.fromEntries(formData.entries());
-    } else if (element.tagName === 'INPUT' || element.tagName === 'TEXTAREA' || element.tagName === 'SELECT') {
+    } else if (
+      element.tagName === "INPUT" ||
+      element.tagName === "TEXTAREA" ||
+      element.tagName === "SELECT"
+    ) {
       const input = element;
-      data[input.name || 'value'] = input.value;
+      data[input.name || "value"] = input.value;
     }
 
     // Add any additional data from wx-data attribute
-    const wxData = element.getAttribute('wx-data');
+    const wxData = element.getAttribute("wx-data");
     if (wxData) {
       try {
         const additionalData = JSON.parse(wxData);
         data = { ...data, ...additionalData };
       } catch (error) {
-        this.log('Error parsing wx-data:', error);
+        this.log("Error parsing wx-data:", error);
+      }
+    }
+
+    // Add data-* attributes to request data
+    for (const attr of element.attributes) {
+      if (attr.name.startsWith("data-") && !attr.name.startsWith("data-wsx")) {
+        const key = attr.name.substring(5); // Remove 'data-' prefix
+        data[key] = attr.value;
       }
     }
 
@@ -606,14 +1121,14 @@ class WSX {
       target,
       trigger,
       data,
-      element
+      element,
     };
 
     this.pendingRequests.set(request.id, request);
 
     // Trigger before request event
-    const beforeEvent = new CustomEvent('wsx:beforeRequest', {
-      detail: { request, element }
+    const beforeEvent = new CustomEvent("wsx:beforeRequest", {
+      detail: { request, element },
     });
     element.dispatchEvent(beforeEvent);
 
@@ -624,22 +1139,42 @@ class WSX {
       target,
       trigger,
       data,
-      swap
+      swap,
     });
   }
 
   send(message) {
+    const isJsonMessage =
+      message && typeof message === "object" && message.type === "json";
+
+    if (this.demoMode) {
+      if (isJsonMessage) {
+        this.log("Cannot send JSON message: demo mode active");
+        return;
+      }
+
+      // Handle demo mode with simulated responses
+      setTimeout(() => {
+        const demoResponse = this.generateDemoResponse(message);
+        this.handleMessage(demoResponse);
+      }, 100 + Math.random() * 300); // Simulate network delay
+      return;
+    }
+
     if (this.ws && this.isConnected) {
       this.ws.send(JSON.stringify(message));
-      this.log('Sent message:', message);
+      this.log(
+        isJsonMessage ? "Sent JSON message:" : "Sent message:",
+        message
+      );
     } else {
-      this.log('Cannot send message: not connected');
+      this.log("Cannot send message: not connected");
     }
   }
 
   log(...args) {
     if (this.config.debug) {
-      console.log('[WSX]', ...args);
+      console.log("[WSX]", ...args);
     }
   }
 
@@ -663,20 +1198,20 @@ class WSX {
   // Programmatic trigger
   trigger(selector, data) {
     const element = document.querySelector(selector);
-    if (element && element.hasAttribute('wx-send')) {
+    if (element && element.hasAttribute("wx-send")) {
       if (data) {
-        element.setAttribute('wx-data', JSON.stringify(data));
+        element.setAttribute("wx-data", JSON.stringify(data));
       }
-      this.handleTrigger(element, 'programmatic');
+      this.handleTrigger(element, "programmatic");
     }
   }
 }
 
 // Auto-initialize if wx-config is present
-document.addEventListener('DOMContentLoaded', () => {
-  const configElement = document.querySelector('[wx-config]');
+document.addEventListener("DOMContentLoaded", () => {
+  const configElement = document.querySelector("[wx-config]");
   if (configElement) {
-    const config = JSON.parse(configElement.getAttribute('wx-config') || '{}');
+    const config = JSON.parse(configElement.getAttribute("wx-config") || "{}");
     window.wsx = new WSX(config);
   }
 });

--- a/examples/hono/public/wsx.js
+++ b/examples/hono/public/wsx.js
@@ -30,6 +30,35 @@
  * @property {HTMLElement} [element] - Source element
  */
 
+/**
+ * @typedef {Object} WSXStreamOptions
+ * @property {string} [id] - Optional stream identifier
+ * @property {Object} [metadata] - Additional metadata to include with the stream
+ */
+
+/**
+ * @typedef {Object} WSXJSONOptions
+ * @property {string} [id] - Optional JSON message identifier
+ * @property {Object} [metadata] - Additional metadata to include with the message
+ */
+
+/**
+ * @typedef {Object} WSXJSONDetail
+ * @property {string} id - Message identifier
+ * @property {string} channel - Channel the JSON message was published to
+ * @property {Object} metadata - Optional metadata provided by the sender
+ * @property {*} data - The JSON payload
+ */
+
+/**
+ * @typedef {Object} WSXStreamDetail
+ * @property {string} id - Stream identifier
+ * @property {string} channel - Logical channel for the stream
+ * @property {Object} metadata - Metadata provided by the sender
+ * @property {Uint8Array} data - Raw binary payload
+ * @property {ArrayBuffer} arrayBuffer - Copy of the payload as an ArrayBuffer
+ */
+
 class WSX {
   /**
    * @param {WSXConfig} config - Configuration object
@@ -42,14 +71,18 @@ class WSX {
     this.requestCounter = 0;
     this.throttleTimers = new Map();
     this.debounceTimers = new Map();
-    
+    this.streamHandlers = new Map();
+    this.jsonHandlers = new Map();
+    this.textEncoder = new TextEncoder();
+    this.textDecoder = new TextDecoder();
+
     this.config = {
       reconnectInterval: 3000,
       maxReconnectAttempts: 5,
       debug: false,
-      ...config
+      ...config,
     };
-    
+
     this.connect();
     this.setupEventListeners();
   }
@@ -57,12 +90,13 @@ class WSX {
   connect() {
     try {
       this.ws = new WebSocket(this.config.url);
+      this.ws.binaryType = "arraybuffer";
       this.ws.onopen = this.onOpen.bind(this);
       this.ws.onmessage = this.onMessage.bind(this);
       this.ws.onclose = this.onClose.bind(this);
       this.ws.onerror = this.onError.bind(this);
     } catch (error) {
-      this.log('Connection failed:', error);
+      this.log("Connection failed:", error);
       this.scheduleReconnect();
     }
   }
@@ -70,57 +104,504 @@ class WSX {
   onOpen() {
     this.isConnected = true;
     this.reconnectAttempts = 0;
-    this.log('Connected to WSX server');
-    
+    this.log("Connected to WSX server");
+
     // Trigger connection event
-    document.dispatchEvent(new CustomEvent('wsx:connected'));
+    document.dispatchEvent(new CustomEvent("wsx:connected"));
   }
 
-  onMessage(event) {
+  async onMessage(event) {
     try {
-      const message = JSON.parse(event.data);
-      this.handleMessage(message);
+      if (typeof event.data === "string") {
+        const message = JSON.parse(event.data);
+        this.handleMessage(message);
+      } else {
+        await this.handleBinaryMessage(event.data);
+      }
     } catch (error) {
-      this.log('Error parsing message:', error);
+      this.log("Error processing message:", error);
     }
+  }
+
+  async handleBinaryMessage(data) {
+    try {
+      const bytes = await this.toUint8Array(data);
+
+      if (bytes.byteLength < 4) {
+        throw new Error("Stream message too small");
+      }
+
+      const view = new DataView(
+        bytes.buffer,
+        bytes.byteOffset,
+        bytes.byteLength
+      );
+      const headerLength = view.getUint32(0, false);
+      const headerStart = 4;
+      const headerEnd = headerStart + headerLength;
+
+      if (bytes.byteLength < headerEnd) {
+        throw new Error("Stream message header incomplete");
+      }
+
+      const headerBytes = bytes.subarray(headerStart, headerEnd);
+      const headerString = this.textDecoder.decode(headerBytes);
+      const header = JSON.parse(headerString);
+
+      if (!header || header.type !== "stream") {
+        this.log("Unsupported binary message received", header);
+        return;
+      }
+
+      if (typeof header.id !== "string" || typeof header.channel !== "string") {
+        throw new Error("Invalid stream header");
+      }
+
+      const payload = bytes.subarray(headerEnd);
+
+      this.dispatchStream(
+        {
+          id: header.id,
+          channel: header.channel,
+          metadata: header.metadata || {},
+        },
+        payload
+      );
+    } catch (error) {
+      this.log("Error handling binary message:", error);
+    }
+  }
+
+  /**
+   * Dispatch an incoming JSON message to registered handlers and DOM listeners.
+   * @param {{id?: string, channel: string, metadata?: Object, data: any, type?: string}} message
+   */
+  dispatchJson(message) {
+    if (!message || typeof message.channel !== "string") {
+      this.log("Invalid JSON message received", message);
+      return;
+    }
+
+    const detail = {
+      id:
+        typeof message.id === "string"
+          ? message.id
+          : this.generateJsonId(),
+      channel: message.channel,
+      metadata:
+        message.metadata && typeof message.metadata === "object"
+          ? message.metadata
+          : {},
+      data: message.data,
+    };
+
+    const handler =
+      this.jsonHandlers.get(detail.channel) || this.jsonHandlers.get("");
+
+    if (handler) {
+      try {
+        handler(detail);
+      } catch (error) {
+        this.log("Error in JSON handler:", error);
+      }
+    }
+
+    document.dispatchEvent(new CustomEvent("wsx:json", { detail }));
+  }
+
+  /**
+   * Dispatch a decoded stream payload to registered handlers and DOM listeners.
+   * @param {{id: string, channel: string, metadata: Object}} message - Stream metadata
+   * @param {Uint8Array} payload - Binary payload for the stream message
+   */
+  dispatchStream(message, payload) {
+    const detail = {
+      id: message.id,
+      channel: message.channel,
+      metadata: message.metadata || {},
+      data: payload,
+      arrayBuffer: payload.buffer.slice(
+        payload.byteOffset,
+        payload.byteOffset + payload.byteLength
+      ),
+    };
+
+    const handler =
+      this.streamHandlers.get(message.channel) ||
+      this.streamHandlers.get("");
+
+    if (handler) {
+      try {
+        handler(detail);
+      } catch (error) {
+        this.log("Error in stream handler:", error);
+      }
+    }
+
+    document.dispatchEvent(new CustomEvent("wsx:stream", { detail }));
+  }
+
+  /**
+   * Register a handler for incoming stream data.
+   * @param {string|function} channelOrHandler - Channel name or catch-all handler
+   * @param {function} [handler] - Handler invoked when the specified channel receives data
+   * @returns {WSX} The WSX instance for chaining
+   */
+  onJson(channelOrHandler, handler) {
+    if (typeof channelOrHandler === "string") {
+      if (typeof handler !== "function") {
+        throw new Error("JSON handler must be a function");
+      }
+      this.jsonHandlers.set(channelOrHandler, handler);
+    } else if (typeof channelOrHandler === "function") {
+      this.jsonHandlers.set("", channelOrHandler);
+    } else {
+      throw new Error("Invalid JSON handler registration");
+    }
+
+    return this;
+  }
+
+  /**
+   * Remove a previously registered JSON handler.
+   * @param {string} [channel] - Channel to remove; omitting clears all handlers
+   * @returns {WSX} The WSX instance for chaining
+   */
+  offJson(channel) {
+    if (typeof channel === "string") {
+      this.jsonHandlers.delete(channel);
+    } else {
+      this.jsonHandlers.clear();
+    }
+
+    return this;
+  }
+
+  /**
+   * Register a handler for incoming stream data.
+   * @param {string|function} channelOrHandler - Channel name or catch-all handler
+   * @param {function} [handler] - Handler invoked when the specified channel receives data
+   * @returns {WSX} The WSX instance for chaining
+   */
+  onStream(channelOrHandler, handler) {
+    if (typeof channelOrHandler === "string") {
+      if (typeof handler !== "function") {
+        throw new Error("Stream handler must be a function");
+      }
+      this.streamHandlers.set(channelOrHandler, handler);
+    } else if (typeof channelOrHandler === "function") {
+      this.streamHandlers.set("", channelOrHandler);
+    } else {
+      throw new Error("Invalid stream handler registration");
+    }
+
+    return this;
+  }
+
+  /**
+   * Remove a previously registered stream handler.
+   * @param {string} [channel] - Channel to remove; omitting clears all handlers
+   * @returns {WSX} The WSX instance for chaining
+   */
+  offStream(channel) {
+    if (typeof channel === "string") {
+      this.streamHandlers.delete(channel);
+    } else {
+      this.streamHandlers.clear();
+    }
+
+    return this;
+  }
+
+  generateStreamId() {
+    return `stream_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+  }
+
+  generateJsonId() {
+    return `json_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+  }
+
+  /**
+   * Send a binary stream payload to the server.
+   * @param {string} channel - Logical channel name used by server handlers
+   * @param {ArrayBuffer|ArrayBufferView|Blob} data - Binary payload to transmit
+   * @param {WSXStreamOptions} [options] - Additional stream options
+   * @returns {Promise<string>} Resolves with the stream identifier
+   */
+  async sendStream(channel, data, options = {}) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new Error("Cannot send stream: connection is not open");
+    }
+
+    const streamId = options.id || this.generateStreamId();
+    const header = {
+      type: "stream",
+      id: streamId,
+      channel,
+    };
+
+    if (options.metadata !== undefined) {
+      header.metadata = options.metadata;
+    }
+
+    const headerBytes = this.textEncoder.encode(JSON.stringify(header));
+    const headerLengthBuffer = new ArrayBuffer(4);
+    new DataView(headerLengthBuffer).setUint32(
+      0,
+      headerBytes.byteLength,
+      false
+    );
+    const headerLengthBytes = new Uint8Array(headerLengthBuffer);
+    const payloadBytes = await this.toUint8Array(data);
+    const frame = new Uint8Array(
+      4 + headerBytes.byteLength + payloadBytes.byteLength
+    );
+    frame.set(headerLengthBytes, 0);
+    frame.set(headerBytes, 4);
+    frame.set(payloadBytes, 4 + headerBytes.byteLength);
+
+    this.ws.send(frame);
+
+    return streamId;
+  }
+
+  /**
+   * Send a JSON message payload to the server.
+   * @param {string} channel - Logical channel name used by server handlers
+   * @param {*} data - JSON-serializable payload to transmit
+   * @param {WSXJSONOptions} [options] - Additional message options
+   * @returns {string} Identifier of the sent JSON message
+   */
+  sendJson(channel, data, options = {}) {
+    if (this.demoMode) {
+      throw new Error("Cannot send JSON messages while demo mode is active");
+    }
+
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new Error("Cannot send JSON message: connection is not open");
+    }
+
+    const message = {
+      type: "json",
+      id: options.id || this.generateJsonId(),
+      channel,
+      data,
+    };
+
+    if (options.metadata !== undefined) {
+      message.metadata = options.metadata;
+    }
+
+    this.send(message);
+
+    return message.id;
+  }
+
+  /**
+   * Normalise a variety of binary inputs into a Uint8Array view.
+   * @param {ArrayBuffer|ArrayBufferView|Blob} data - Incoming binary data
+   * @returns {Promise<Uint8Array>} View of the provided binary data
+   */
+  async toUint8Array(data) {
+    if (data instanceof ArrayBuffer) {
+      return new Uint8Array(data);
+    }
+
+    if (ArrayBuffer.isView(data)) {
+      return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+    }
+
+    if (typeof Blob !== "undefined" && data instanceof Blob) {
+      const buffer = await data.arrayBuffer();
+      return new Uint8Array(buffer);
+    }
+
+    throw new Error("Unsupported binary data type");
   }
 
   onClose() {
     this.isConnected = false;
-    this.log('Disconnected from WSX server');
-    
+    this.log("Disconnected from WSX server");
+
     // Trigger disconnection event
-    document.dispatchEvent(new CustomEvent('wsx:disconnected'));
-    
+    document.dispatchEvent(new CustomEvent("wsx:disconnected"));
+
     if (this.reconnectAttempts < this.config.maxReconnectAttempts) {
       this.scheduleReconnect();
     }
   }
 
   onError(error) {
-    this.log('WebSocket error:', error);
+    this.log("WebSocket error:", error);
+    // Enable demo mode if connection fails
+    this.enableDemoMode();
   }
 
   scheduleReconnect() {
+    if (this.reconnectAttempts >= this.config.maxReconnectAttempts) {
+      this.log("Max reconnect attempts reached, enabling demo mode");
+      this.enableDemoMode();
+      return;
+    }
+
     setTimeout(() => {
       this.reconnectAttempts++;
-      this.log(`Reconnection attempt ${this.reconnectAttempts}/${this.config.maxReconnectAttempts}`);
+      this.log(
+        `Reconnection attempt ${this.reconnectAttempts}/${this.config.maxReconnectAttempts}`
+      );
       this.connect();
     }, this.config.reconnectInterval);
   }
 
+  enableDemoMode() {
+    this.demoMode = true;
+    this.isConnected = true; // Simulate connection for demo
+    this.log("Demo mode enabled - simulating WebSocket responses");
+
+    // Update live indicator
+    const liveStats = document.getElementById("live-stats");
+    if (liveStats) {
+      liveStats.innerHTML = `
+        <span class="live-dot"></span>
+        Demo Mode (WebSocket simulation)
+      `;
+    }
+  }
+
+  generateDemoResponse(request) {
+    const responses = {
+      "animate-hero": {
+        id: request.id,
+        target: request.target,
+        html: `<div class="glitch-text">🚀 WSX: HYPERMEDIA GOES REAL-TIME 🚀</div>`,
+      },
+      "show-feature": {
+        id: request.id,
+        target: request.target,
+        html: this.generateFeatureShowcase(request.data?.feature || "realtime"),
+      },
+      "demo-interaction": {
+        id: request.id,
+        target: request.target,
+        html: `<div class="demo-response pulse">🎉 WSX Magic Happened! 🎉</div>`,
+      },
+      "get-stats": {
+        id: request.id,
+        target: request.target,
+        html: `
+          <div class="stats-grid animate-fade-in">
+            <div class="stat-item">
+              <div class="stat-number neon-text">1</div>
+              <div class="stat-label">Demo Connections</div>
+            </div>
+            <div class="stat-item">
+              <div class="stat-number neon-text">${Math.floor(
+                Math.random() * 10000
+              ).toLocaleString()}</div>
+              <div class="stat-label">DOM Updates</div>
+            </div>
+            <div class="stat-item">
+              <div class="stat-number neon-text">3</div>
+              <div class="stat-label">Frameworks</div>
+            </div>
+            <div class="stat-item">
+              <div class="stat-number neon-text">v1.0.0</div>
+              <div class="stat-label">Version</div>
+            </div>
+          </div>
+        `,
+      },
+    };
+
+    return (
+      responses[request.handler] || {
+        id: request.id,
+        target: request.target,
+        html: `<div class="demo-response">Demo response for: ${request.handler}</div>`,
+      }
+    );
+  }
+
+  generateFeatureShowcase(feature) {
+    const features = {
+      realtime: {
+        icon: "⚡",
+        title: "Real-Time Hypermedia",
+        description: "HTMX-style patterns with WebSocket power",
+        code: `wsx.on("update", async (req, conn) => {
+  return {
+    target: "#content",
+    html: \`<div class="live">\${data}</div>\`
+  };
+});`,
+      },
+      oob: {
+        icon: "🎯",
+        title: "Out-of-Band Updates",
+        description: "Update multiple DOM elements simultaneously",
+        code: `return {
+  target: "#main",
+  html: \`<div>Main content</div>\`,
+  oob: [{
+    target: "#sidebar",
+    html: \`<div>Sidebar update</div>\`
+  }]
+};`,
+      },
+      triggers: {
+        icon: "🎮",
+        title: "Advanced Triggers",
+        description: "Rich trigger system with debouncing and conditions",
+        code: `<input 
+  wx-send="search"
+  wx-trigger="keyup delay:300ms"
+  wx-target="#results"
+/>`,
+      },
+      framework: {
+        icon: "🔧",
+        title: "Framework Agnostic",
+        description: "Works with Express, Hono, and custom adapters",
+        code: `import { createHonoWSXServer } from "@wsx-sh/hono";
+import { createExpressWSXServer } from "@wsx-sh/express";
+
+const wsx = createHonoWSXServer();`,
+      },
+    };
+
+    const featureData = features[feature] || features.realtime;
+
+    return `
+      <div class="feature-showcase animate-in">
+        <div class="feature-icon">${featureData.icon}</div>
+        <h3 class="neon-text">${featureData.title}</h3>
+        <p class="feature-description">${featureData.description}</p>
+        <pre class="code-block"><code>${featureData.code}</code></pre>
+        <div class="feature-glow"></div>
+      </div>
+    `;
+  }
+
   handleMessage(message) {
+    if (message && typeof message === "object" && message.type === "json") {
+      this.dispatchJson(message);
+      return;
+    }
+
     // Handle main response
-    this.processSwapUpdate({
-      target: message.target,
-      html: message.html,
-      swap: message.swap || 'innerHTML'
-    }, message);
+    this.processSwapUpdate(
+      {
+        target: message.target,
+        html: message.html,
+        swap: message.swap || "innerHTML",
+      },
+      message
+    );
 
     // Handle out-of-band swaps
     if (message.oob && Array.isArray(message.oob)) {
-      message.oob.forEach(oobUpdate => {
-        this.log('Processing OOB update:', oobUpdate);
+      message.oob.forEach((oobUpdate) => {
+        this.log("Processing OOB update:", oobUpdate);
         this.processSwapUpdate(oobUpdate, message, true);
       });
     }
@@ -137,29 +618,31 @@ class WSX {
    */
   processSwapUpdate(update, message, isOOB = false) {
     const targetElement = document.querySelector(update.target);
-    
+
     if (!targetElement) {
-      this.log(`Target element not found: ${update.target}${isOOB ? ' (OOB)' : ''}`);
+      this.log(
+        `Target element not found: ${update.target}${isOOB ? " (OOB)" : ""}`
+      );
       return;
     }
 
-    const swap = update.swap || 'innerHTML';
+    const swap = update.swap || "innerHTML";
     const swapSpec = this.parseSwapSpec(swap);
-    
+
     // Trigger before swap event
-    const beforeEvent = new CustomEvent('wsx:beforeSwap', {
-      detail: { 
-        message, 
-        element: targetElement, 
+    const beforeEvent = new CustomEvent("wsx:beforeSwap", {
+      detail: {
+        message,
+        element: targetElement,
         update,
-        isOOB 
-      }
+        isOOB,
+      },
     });
     targetElement.dispatchEvent(beforeEvent);
 
     // Apply swap delay if specified
     const delay = swapSpec.swap || 0;
-    
+
     setTimeout(() => {
       // Perform the swap
       this.performSwap(targetElement, update.html, swapSpec);
@@ -167,13 +650,13 @@ class WSX {
       // Apply settle delay and trigger after swap event
       const settleDelay = swapSpec.settle || 20;
       setTimeout(() => {
-        const afterEvent = new CustomEvent('wsx:afterSwap', {
-          detail: { 
-            message, 
-            element: targetElement, 
+        const afterEvent = new CustomEvent("wsx:afterSwap", {
+          detail: {
+            message,
+            element: targetElement,
             update,
-            isOOB 
-          }
+            isOOB,
+          },
         });
         targetElement.dispatchEvent(afterEvent);
 
@@ -182,36 +665,35 @@ class WSX {
           this.handleShowScroll(targetElement, swapSpec);
         }
       }, settleDelay);
-
     }, delay);
   }
 
   performSwap(element, html, swapSpec) {
-    const swapStyle = swapSpec.style || 'innerHTML';
-    
+    const swapStyle = swapSpec.style || "innerHTML";
+
     switch (swapStyle) {
-      case 'innerHTML':
+      case "innerHTML":
         element.innerHTML = html;
         break;
-      case 'outerHTML':
+      case "outerHTML":
         element.outerHTML = html;
         break;
-      case 'beforebegin':
-        element.insertAdjacentHTML('beforebegin', html);
+      case "beforebegin":
+        element.insertAdjacentHTML("beforebegin", html);
         break;
-      case 'afterbegin':
-        element.insertAdjacentHTML('afterbegin', html);
+      case "afterbegin":
+        element.insertAdjacentHTML("afterbegin", html);
         break;
-      case 'beforeend':
-        element.insertAdjacentHTML('beforeend', html);
+      case "beforeend":
+        element.insertAdjacentHTML("beforeend", html);
         break;
-      case 'afterend':
-        element.insertAdjacentHTML('afterend', html);
+      case "afterend":
+        element.insertAdjacentHTML("afterend", html);
         break;
-      case 'delete':
+      case "delete":
         element.remove();
         break;
-      case 'none':
+      case "none":
         // Do nothing - useful for side effects only
         break;
       default:
@@ -226,43 +708,43 @@ class WSX {
    */
   parseSwapSpec(swapString) {
     const spec = {
-      style: 'innerHTML',
+      style: "innerHTML",
       swap: 0,
       settle: 20,
       show: null,
       scroll: null,
-      focus: false
+      focus: false,
     };
 
     if (!swapString) return spec;
 
     const parts = swapString.trim().split(/\s+/);
-    
+
     // First part is the swap style if it doesn't contain ':'
-    if (parts[0] && !parts[0].includes(':')) {
+    if (parts[0] && !parts[0].includes(":")) {
       spec.style = parts[0];
       parts.shift();
     }
 
     // Parse modifiers
-    parts.forEach(part => {
-      const [key, value] = part.split(':');
-      
+    parts.forEach((part) => {
+      const [key, value] = part.split(":");
+
       switch (key) {
-        case 'swap':
+        case "swap":
           spec.swap = this.parseTime(value);
           break;
-        case 'settle':
+        case "settle":
           spec.settle = this.parseTime(value);
           break;
-        case 'show':
-          spec.show = value || 'top';
+        case "show":
+          spec.show = value || "top";
           break;
-        case 'scroll':
-          spec.scroll = value || 'top';
+        case "scroll":
+          spec.scroll = value || "top";
           break;
-        case 'focus-scroll':
-          spec.focus = value !== 'false';
+        case "focus-scroll":
+          spec.focus = value !== "false";
           break;
       }
     });
@@ -277,14 +759,14 @@ class WSX {
    */
   parseTime(timeStr) {
     if (!timeStr) return 0;
-    
+
     const match = timeStr.match(/^(\d+(?:\.\d+)?)(ms|s)?$/);
     if (!match) return 0;
-    
+
     const value = parseFloat(match[1]);
-    const unit = match[2] || 'ms';
-    
-    return unit === 's' ? value * 1000 : value;
+    const unit = match[2] || "ms";
+
+    return unit === "s" ? value * 1000 : value;
   }
 
   /**
@@ -294,9 +776,10 @@ class WSX {
    */
   handleShowScroll(element, swapSpec) {
     if (swapSpec.show || swapSpec.scroll) {
-      const targetEl = swapSpec.show === 'window' || swapSpec.scroll === 'window' 
-        ? window 
-        : element;
+      const targetEl =
+        swapSpec.show === "window" || swapSpec.scroll === "window"
+          ? window
+          : element;
 
       if (swapSpec.show) {
         this.scrollIntoView(targetEl, swapSpec.show);
@@ -313,25 +796,25 @@ class WSX {
    */
   scrollIntoView(target, position) {
     if (target === window) {
-      const scrollPos = position === 'bottom' ? document.body.scrollHeight : 0;
-      window.scrollTo({ top: scrollPos, behavior: 'smooth' });
+      const scrollPos = position === "bottom" ? document.body.scrollHeight : 0;
+      window.scrollTo({ top: scrollPos, behavior: "smooth" });
       return;
     }
 
-    const options = { behavior: 'smooth' };
-    
+    const options = { behavior: "smooth" };
+
     switch (position) {
-      case 'top':
-        options.block = 'start';
+      case "top":
+        options.block = "start";
         break;
-      case 'bottom':
-        options.block = 'end';
+      case "bottom":
+        options.block = "end";
         break;
-      case 'center':
-        options.block = 'center';
+      case "center":
+        options.block = "center";
         break;
       default:
-        options.block = 'nearest';
+        options.block = "nearest";
     }
 
     target.scrollIntoView(options);
@@ -339,35 +822,48 @@ class WSX {
 
   setupEventListeners() {
     // Common events to listen for
-    const events = ['click', 'submit', 'input', 'change', 'keyup', 'keydown', 'focus', 'blur', 'load', 'scroll', 'mouseover', 'mouseout'];
-    
-    events.forEach(eventType => {
+    const events = [
+      "click",
+      "submit",
+      "input",
+      "change",
+      "keyup",
+      "keydown",
+      "focus",
+      "blur",
+      "load",
+      "scroll",
+      "mouseover",
+      "mouseout",
+    ];
+
+    events.forEach((eventType) => {
       document.addEventListener(eventType, (e) => {
         this.handleEvent(e, eventType);
       });
     });
 
     // Handle intersect events (for lazy loading)
-    if ('IntersectionObserver' in window) {
+    if ("IntersectionObserver" in window) {
       this.setupIntersectionObserver();
     }
   }
 
   handleEvent(e, eventType) {
     let element = e.target;
-    
+
     // Walk up the DOM tree to find elements with wx-send
     while (element && element !== document) {
-      if (element.hasAttribute && element.hasAttribute('wx-send')) {
-        const triggerSpec = element.getAttribute('wx-trigger') || eventType;
+      if (element.hasAttribute && element.hasAttribute("wx-send")) {
+        const triggerSpec = element.getAttribute("wx-trigger") || eventType;
         const triggers = this.parseTriggerSpec(triggerSpec);
-        
+
         for (const trigger of triggers) {
           if (this.shouldTrigger(trigger, e, eventType, element)) {
-            if (eventType === 'submit') {
+            if (eventType === "submit") {
               e.preventDefault();
             }
-            
+
             this.processTrigger(element, trigger, e);
             break; // Only process the first matching trigger
           }
@@ -383,54 +879,54 @@ class WSX {
    * @returns {Array} Array of parsed trigger objects
    */
   parseTriggerSpec(triggerSpec) {
-    if (!triggerSpec) return [{ event: 'click' }];
-    
-    return triggerSpec.split(',').map(spec => {
-      const trigger = { event: 'click', modifiers: {} };
+    if (!triggerSpec) return [{ event: "click" }];
+
+    return triggerSpec.split(",").map((spec) => {
+      const trigger = { event: "click", modifiers: {} };
       const parts = spec.trim().split(/\s+/);
-      
+
       // Parse event name and conditions
       const eventPart = parts[0];
       const conditionMatch = eventPart.match(/^(\w+)(?:\[([^\]]+)\])?$/);
-      
+
       if (conditionMatch) {
         trigger.event = conditionMatch[1];
         if (conditionMatch[2]) {
           trigger.condition = conditionMatch[2];
         }
       }
-      
+
       // Parse modifiers
-      parts.slice(1).forEach(part => {
-        const [key, value] = part.split(':');
+      parts.slice(1).forEach((part) => {
+        const [key, value] = part.split(":");
         switch (key) {
-          case 'once':
+          case "once":
             trigger.modifiers.once = true;
             break;
-          case 'changed':
+          case "changed":
             trigger.modifiers.changed = true;
             break;
-          case 'delay':
+          case "delay":
             trigger.modifiers.delay = this.parseTime(value);
             break;
-          case 'throttle':
+          case "throttle":
             trigger.modifiers.throttle = this.parseTime(value);
             break;
-          case 'from':
+          case "from":
             trigger.modifiers.from = value;
             break;
-          case 'target':
+          case "target":
             trigger.modifiers.target = value;
             break;
-          case 'consume':
+          case "consume":
             trigger.modifiers.consume = true;
             break;
-          case 'queue':
-            trigger.modifiers.queue = value || 'last';
+          case "queue":
+            trigger.modifiers.queue = value || "last";
             break;
         }
       });
-      
+
       return trigger;
     });
   }
@@ -441,47 +937,50 @@ class WSX {
   shouldTrigger(trigger, event, eventType, element) {
     // Check if event type matches
     if (trigger.event !== eventType) return false;
-    
+
     // Check condition (e.g., ctrlKey, shiftKey, etc.)
     if (trigger.condition) {
       try {
         // Simple condition evaluation for common cases
-        if (trigger.condition.includes('ctrlKey') && !event.ctrlKey) return false;
-        if (trigger.condition.includes('shiftKey') && !event.shiftKey) return false;
-        if (trigger.condition.includes('altKey') && !event.altKey) return false;
-        if (trigger.condition.includes('metaKey') && !event.metaKey) return false;
-        
+        if (trigger.condition.includes("ctrlKey") && !event.ctrlKey)
+          return false;
+        if (trigger.condition.includes("shiftKey") && !event.shiftKey)
+          return false;
+        if (trigger.condition.includes("altKey") && !event.altKey) return false;
+        if (trigger.condition.includes("metaKey") && !event.metaKey)
+          return false;
+
         // Handle key conditions like "keyup[Enter]"
         const keyMatch = trigger.condition.match(/^(\w+)$/);
         if (keyMatch && event.key !== keyMatch[1]) return false;
       } catch (e) {
-        this.log('Error evaluating trigger condition:', e);
+        this.log("Error evaluating trigger condition:", e);
         return false;
       }
     }
-    
+
     // Check 'from' modifier (event delegation)
     if (trigger.modifiers.from) {
       const fromElement = document.querySelector(trigger.modifiers.from);
       if (!fromElement || !fromElement.contains(event.target)) return false;
     }
-    
+
     // Check 'target' modifier
     if (trigger.modifiers.target) {
       if (!event.target.matches(trigger.modifiers.target)) return false;
     }
-    
+
     // Check 'changed' modifier for form inputs
     if (trigger.modifiers.changed && element.tagName) {
       const tagName = element.tagName.toLowerCase();
-      if (['input', 'textarea', 'select'].includes(tagName)) {
+      if (["input", "textarea", "select"].includes(tagName)) {
         const currentValue = element.value;
         const lastValue = element.dataset.wsxLastValue;
         if (currentValue === lastValue) return false;
         element.dataset.wsxLastValue = currentValue;
       }
     }
-    
+
     return true;
   }
 
@@ -489,59 +988,63 @@ class WSX {
    * Process trigger with modifiers like delay, throttle, etc.
    */
   processTrigger(element, trigger, event) {
-    const elementId = element.id || `wsx_${Math.random().toString(36).substr(2, 9)}`;
+    const elementId =
+      element.id || `wsx_${Math.random().toString(36).substr(2, 9)}`;
     if (!element.id) element.id = elementId;
-    
+
     // Handle 'once' modifier
     if (trigger.modifiers.once) {
       if (element.dataset.wsxTriggered) return;
-      element.dataset.wsxTriggered = 'true';
+      element.dataset.wsxTriggered = "true";
     }
-    
+
     // Handle 'consume' modifier
     if (trigger.modifiers.consume) {
       event.stopPropagation();
     }
-    
+
     const executeRequest = () => {
       this.handleTrigger(element, trigger.event, event);
     };
-    
+
     // Handle 'delay' modifier
     if (trigger.modifiers.delay) {
       setTimeout(executeRequest, trigger.modifiers.delay);
       return;
     }
-    
+
     // Handle 'throttle' modifier
     if (trigger.modifiers.throttle) {
       const throttleKey = `${elementId}_${trigger.event}`;
       if (this.throttleTimers.has(throttleKey)) return;
-      
+
       executeRequest();
-      this.throttleTimers.set(throttleKey, setTimeout(() => {
-        this.throttleTimers.delete(throttleKey);
-      }, trigger.modifiers.throttle));
+      this.throttleTimers.set(
+        throttleKey,
+        setTimeout(() => {
+          this.throttleTimers.delete(throttleKey);
+        }, trigger.modifiers.throttle)
+      );
       return;
     }
-    
+
     // Handle 'queue' modifier with debouncing
     if (trigger.modifiers.queue) {
       const debounceKey = `${elementId}_${trigger.event}`;
-      
+
       if (this.debounceTimers.has(debounceKey)) {
         clearTimeout(this.debounceTimers.get(debounceKey));
       }
-      
+
       const timer = setTimeout(() => {
         this.debounceTimers.delete(debounceKey);
         executeRequest();
       }, 300); // Default debounce time
-      
+
       this.debounceTimers.set(debounceKey, timer);
       return;
     }
-    
+
     // Execute immediately
     executeRequest();
   }
@@ -551,17 +1054,17 @@ class WSX {
    */
   setupIntersectionObserver() {
     const observer = new IntersectionObserver((entries) => {
-      entries.forEach(entry => {
+      entries.forEach((entry) => {
         if (entry.isIntersecting) {
           const element = entry.target;
-          this.handleTrigger(element, 'intersect');
+          this.handleTrigger(element, "intersect");
         }
       });
     });
-    
+
     // Observe elements with intersect triggers
-    document.addEventListener('DOMContentLoaded', () => {
-      document.querySelectorAll('[wx-trigger*="intersect"]').forEach(el => {
+    document.addEventListener("DOMContentLoaded", () => {
+      document.querySelectorAll('[wx-trigger*="intersect"]').forEach((el) => {
         observer.observe(el);
       });
     });
@@ -569,34 +1072,46 @@ class WSX {
 
   handleTrigger(element, eventType, event) {
     if (!this.isConnected) {
-      this.log('Not connected to server');
+      this.log("Not connected to server");
       return;
     }
 
-    const handler = element.getAttribute('wx-send') || '';
-    const target = element.getAttribute('wx-target') || 'body';
-    const swap = element.getAttribute('wx-swap') || 'innerHTML';
-    const trigger = element.getAttribute('wx-trigger') || eventType;
+    const handler = element.getAttribute("wx-send") || "";
+    const target = element.getAttribute("wx-target") || "body";
+    const swap = element.getAttribute("wx-swap") || "innerHTML";
+    const trigger = element.getAttribute("wx-trigger") || eventType;
 
     // Collect form data if it's a form element
     let data = {};
-    
-    if (element.tagName === 'FORM') {
+
+    if (element.tagName === "FORM") {
       const formData = new FormData(element);
       data = Object.fromEntries(formData.entries());
-    } else if (element.tagName === 'INPUT' || element.tagName === 'TEXTAREA' || element.tagName === 'SELECT') {
+    } else if (
+      element.tagName === "INPUT" ||
+      element.tagName === "TEXTAREA" ||
+      element.tagName === "SELECT"
+    ) {
       const input = element;
-      data[input.name || 'value'] = input.value;
+      data[input.name || "value"] = input.value;
     }
 
     // Add any additional data from wx-data attribute
-    const wxData = element.getAttribute('wx-data');
+    const wxData = element.getAttribute("wx-data");
     if (wxData) {
       try {
         const additionalData = JSON.parse(wxData);
         data = { ...data, ...additionalData };
       } catch (error) {
-        this.log('Error parsing wx-data:', error);
+        this.log("Error parsing wx-data:", error);
+      }
+    }
+
+    // Add data-* attributes to request data
+    for (const attr of element.attributes) {
+      if (attr.name.startsWith("data-") && !attr.name.startsWith("data-wsx")) {
+        const key = attr.name.substring(5); // Remove 'data-' prefix
+        data[key] = attr.value;
       }
     }
 
@@ -606,14 +1121,14 @@ class WSX {
       target,
       trigger,
       data,
-      element
+      element,
     };
 
     this.pendingRequests.set(request.id, request);
 
     // Trigger before request event
-    const beforeEvent = new CustomEvent('wsx:beforeRequest', {
-      detail: { request, element }
+    const beforeEvent = new CustomEvent("wsx:beforeRequest", {
+      detail: { request, element },
     });
     element.dispatchEvent(beforeEvent);
 
@@ -624,22 +1139,42 @@ class WSX {
       target,
       trigger,
       data,
-      swap
+      swap,
     });
   }
 
   send(message) {
+    const isJsonMessage =
+      message && typeof message === "object" && message.type === "json";
+
+    if (this.demoMode) {
+      if (isJsonMessage) {
+        this.log("Cannot send JSON message: demo mode active");
+        return;
+      }
+
+      // Handle demo mode with simulated responses
+      setTimeout(() => {
+        const demoResponse = this.generateDemoResponse(message);
+        this.handleMessage(demoResponse);
+      }, 100 + Math.random() * 300); // Simulate network delay
+      return;
+    }
+
     if (this.ws && this.isConnected) {
       this.ws.send(JSON.stringify(message));
-      this.log('Sent message:', message);
+      this.log(
+        isJsonMessage ? "Sent JSON message:" : "Sent message:",
+        message
+      );
     } else {
-      this.log('Cannot send message: not connected');
+      this.log("Cannot send message: not connected");
     }
   }
 
   log(...args) {
     if (this.config.debug) {
-      console.log('[WSX]', ...args);
+      console.log("[WSX]", ...args);
     }
   }
 
@@ -663,20 +1198,20 @@ class WSX {
   // Programmatic trigger
   trigger(selector, data) {
     const element = document.querySelector(selector);
-    if (element && element.hasAttribute('wx-send')) {
+    if (element && element.hasAttribute("wx-send")) {
       if (data) {
-        element.setAttribute('wx-data', JSON.stringify(data));
+        element.setAttribute("wx-data", JSON.stringify(data));
       }
-      this.handleTrigger(element, 'programmatic');
+      this.handleTrigger(element, "programmatic");
     }
   }
 }
 
 // Auto-initialize if wx-config is present
-document.addEventListener('DOMContentLoaded', () => {
-  const configElement = document.querySelector('[wx-config]');
+document.addEventListener("DOMContentLoaded", () => {
+  const configElement = document.querySelector("[wx-config]");
   if (configElement) {
-    const config = JSON.parse(configElement.getAttribute('wx-config') || '{}');
+    const config = JSON.parse(configElement.getAttribute("wx-config") || "{}");
     window.wsx = new WSX(config);
   }
 });

--- a/landing/assets/wsx.js
+++ b/landing/assets/wsx.js
@@ -30,6 +30,35 @@
  * @property {HTMLElement} [element] - Source element
  */
 
+/**
+ * @typedef {Object} WSXStreamOptions
+ * @property {string} [id] - Optional stream identifier
+ * @property {Object} [metadata] - Additional metadata to include with the stream
+ */
+
+/**
+ * @typedef {Object} WSXJSONOptions
+ * @property {string} [id] - Optional JSON message identifier
+ * @property {Object} [metadata] - Additional metadata to include with the message
+ */
+
+/**
+ * @typedef {Object} WSXJSONDetail
+ * @property {string} id - Message identifier
+ * @property {string} channel - Channel the JSON message was published to
+ * @property {Object} metadata - Optional metadata provided by the sender
+ * @property {*} data - The JSON payload
+ */
+
+/**
+ * @typedef {Object} WSXStreamDetail
+ * @property {string} id - Stream identifier
+ * @property {string} channel - Logical channel for the stream
+ * @property {Object} metadata - Metadata provided by the sender
+ * @property {Uint8Array} data - Raw binary payload
+ * @property {ArrayBuffer} arrayBuffer - Copy of the payload as an ArrayBuffer
+ */
+
 class WSX {
   /**
    * @param {WSXConfig} config - Configuration object
@@ -42,6 +71,10 @@ class WSX {
     this.requestCounter = 0;
     this.throttleTimers = new Map();
     this.debounceTimers = new Map();
+    this.streamHandlers = new Map();
+    this.jsonHandlers = new Map();
+    this.textEncoder = new TextEncoder();
+    this.textDecoder = new TextDecoder();
 
     this.config = {
       reconnectInterval: 3000,
@@ -57,6 +90,7 @@ class WSX {
   connect() {
     try {
       this.ws = new WebSocket(this.config.url);
+      this.ws.binaryType = "arraybuffer";
       this.ws.onopen = this.onOpen.bind(this);
       this.ws.onmessage = this.onMessage.bind(this);
       this.ws.onclose = this.onClose.bind(this);
@@ -76,13 +110,313 @@ class WSX {
     document.dispatchEvent(new CustomEvent("wsx:connected"));
   }
 
-  onMessage(event) {
+  async onMessage(event) {
     try {
-      const message = JSON.parse(event.data);
-      this.handleMessage(message);
+      if (typeof event.data === "string") {
+        const message = JSON.parse(event.data);
+        this.handleMessage(message);
+      } else {
+        await this.handleBinaryMessage(event.data);
+      }
     } catch (error) {
-      this.log("Error parsing message:", error);
+      this.log("Error processing message:", error);
     }
+  }
+
+  async handleBinaryMessage(data) {
+    try {
+      const bytes = await this.toUint8Array(data);
+
+      if (bytes.byteLength < 4) {
+        throw new Error("Stream message too small");
+      }
+
+      const view = new DataView(
+        bytes.buffer,
+        bytes.byteOffset,
+        bytes.byteLength
+      );
+      const headerLength = view.getUint32(0, false);
+      const headerStart = 4;
+      const headerEnd = headerStart + headerLength;
+
+      if (bytes.byteLength < headerEnd) {
+        throw new Error("Stream message header incomplete");
+      }
+
+      const headerBytes = bytes.subarray(headerStart, headerEnd);
+      const headerString = this.textDecoder.decode(headerBytes);
+      const header = JSON.parse(headerString);
+
+      if (!header || header.type !== "stream") {
+        this.log("Unsupported binary message received", header);
+        return;
+      }
+
+      if (typeof header.id !== "string" || typeof header.channel !== "string") {
+        throw new Error("Invalid stream header");
+      }
+
+      const payload = bytes.subarray(headerEnd);
+
+      this.dispatchStream(
+        {
+          id: header.id,
+          channel: header.channel,
+          metadata: header.metadata || {},
+        },
+        payload
+      );
+    } catch (error) {
+      this.log("Error handling binary message:", error);
+    }
+  }
+
+  /**
+   * Dispatch an incoming JSON message to registered handlers and DOM listeners.
+   * @param {{id?: string, channel: string, metadata?: Object, data: any, type?: string}} message
+   */
+  dispatchJson(message) {
+    if (!message || typeof message.channel !== "string") {
+      this.log("Invalid JSON message received", message);
+      return;
+    }
+
+    const detail = {
+      id:
+        typeof message.id === "string"
+          ? message.id
+          : this.generateJsonId(),
+      channel: message.channel,
+      metadata:
+        message.metadata && typeof message.metadata === "object"
+          ? message.metadata
+          : {},
+      data: message.data,
+    };
+
+    const handler =
+      this.jsonHandlers.get(detail.channel) || this.jsonHandlers.get("");
+
+    if (handler) {
+      try {
+        handler(detail);
+      } catch (error) {
+        this.log("Error in JSON handler:", error);
+      }
+    }
+
+    document.dispatchEvent(new CustomEvent("wsx:json", { detail }));
+  }
+
+  /**
+   * Dispatch a decoded stream payload to registered handlers and DOM listeners.
+   * @param {{id: string, channel: string, metadata: Object}} message - Stream metadata
+   * @param {Uint8Array} payload - Binary payload for the stream message
+   */
+  dispatchStream(message, payload) {
+    const detail = {
+      id: message.id,
+      channel: message.channel,
+      metadata: message.metadata || {},
+      data: payload,
+      arrayBuffer: payload.buffer.slice(
+        payload.byteOffset,
+        payload.byteOffset + payload.byteLength
+      ),
+    };
+
+    const handler =
+      this.streamHandlers.get(message.channel) ||
+      this.streamHandlers.get("");
+
+    if (handler) {
+      try {
+        handler(detail);
+      } catch (error) {
+        this.log("Error in stream handler:", error);
+      }
+    }
+
+    document.dispatchEvent(new CustomEvent("wsx:stream", { detail }));
+  }
+
+  /**
+   * Register a handler for incoming stream data.
+   * @param {string|function} channelOrHandler - Channel name or catch-all handler
+   * @param {function} [handler] - Handler invoked when the specified channel receives data
+   * @returns {WSX} The WSX instance for chaining
+   */
+  onJson(channelOrHandler, handler) {
+    if (typeof channelOrHandler === "string") {
+      if (typeof handler !== "function") {
+        throw new Error("JSON handler must be a function");
+      }
+      this.jsonHandlers.set(channelOrHandler, handler);
+    } else if (typeof channelOrHandler === "function") {
+      this.jsonHandlers.set("", channelOrHandler);
+    } else {
+      throw new Error("Invalid JSON handler registration");
+    }
+
+    return this;
+  }
+
+  /**
+   * Remove a previously registered JSON handler.
+   * @param {string} [channel] - Channel to remove; omitting clears all handlers
+   * @returns {WSX} The WSX instance for chaining
+   */
+  offJson(channel) {
+    if (typeof channel === "string") {
+      this.jsonHandlers.delete(channel);
+    } else {
+      this.jsonHandlers.clear();
+    }
+
+    return this;
+  }
+
+  /**
+   * Register a handler for incoming stream data.
+   * @param {string|function} channelOrHandler - Channel name or catch-all handler
+   * @param {function} [handler] - Handler invoked when the specified channel receives data
+   * @returns {WSX} The WSX instance for chaining
+   */
+  onStream(channelOrHandler, handler) {
+    if (typeof channelOrHandler === "string") {
+      if (typeof handler !== "function") {
+        throw new Error("Stream handler must be a function");
+      }
+      this.streamHandlers.set(channelOrHandler, handler);
+    } else if (typeof channelOrHandler === "function") {
+      this.streamHandlers.set("", channelOrHandler);
+    } else {
+      throw new Error("Invalid stream handler registration");
+    }
+
+    return this;
+  }
+
+  /**
+   * Remove a previously registered stream handler.
+   * @param {string} [channel] - Channel to remove; omitting clears all handlers
+   * @returns {WSX} The WSX instance for chaining
+   */
+  offStream(channel) {
+    if (typeof channel === "string") {
+      this.streamHandlers.delete(channel);
+    } else {
+      this.streamHandlers.clear();
+    }
+
+    return this;
+  }
+
+  generateStreamId() {
+    return `stream_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+  }
+
+  generateJsonId() {
+    return `json_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+  }
+
+  /**
+   * Send a binary stream payload to the server.
+   * @param {string} channel - Logical channel name used by server handlers
+   * @param {ArrayBuffer|ArrayBufferView|Blob} data - Binary payload to transmit
+   * @param {WSXStreamOptions} [options] - Additional stream options
+   * @returns {Promise<string>} Resolves with the stream identifier
+   */
+  async sendStream(channel, data, options = {}) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new Error("Cannot send stream: connection is not open");
+    }
+
+    const streamId = options.id || this.generateStreamId();
+    const header = {
+      type: "stream",
+      id: streamId,
+      channel,
+    };
+
+    if (options.metadata !== undefined) {
+      header.metadata = options.metadata;
+    }
+
+    const headerBytes = this.textEncoder.encode(JSON.stringify(header));
+    const headerLengthBuffer = new ArrayBuffer(4);
+    new DataView(headerLengthBuffer).setUint32(
+      0,
+      headerBytes.byteLength,
+      false
+    );
+    const headerLengthBytes = new Uint8Array(headerLengthBuffer);
+    const payloadBytes = await this.toUint8Array(data);
+    const frame = new Uint8Array(
+      4 + headerBytes.byteLength + payloadBytes.byteLength
+    );
+    frame.set(headerLengthBytes, 0);
+    frame.set(headerBytes, 4);
+    frame.set(payloadBytes, 4 + headerBytes.byteLength);
+
+    this.ws.send(frame);
+
+    return streamId;
+  }
+
+  /**
+   * Send a JSON message payload to the server.
+   * @param {string} channel - Logical channel name used by server handlers
+   * @param {*} data - JSON-serializable payload to transmit
+   * @param {WSXJSONOptions} [options] - Additional message options
+   * @returns {string} Identifier of the sent JSON message
+   */
+  sendJson(channel, data, options = {}) {
+    if (this.demoMode) {
+      throw new Error("Cannot send JSON messages while demo mode is active");
+    }
+
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new Error("Cannot send JSON message: connection is not open");
+    }
+
+    const message = {
+      type: "json",
+      id: options.id || this.generateJsonId(),
+      channel,
+      data,
+    };
+
+    if (options.metadata !== undefined) {
+      message.metadata = options.metadata;
+    }
+
+    this.send(message);
+
+    return message.id;
+  }
+
+  /**
+   * Normalise a variety of binary inputs into a Uint8Array view.
+   * @param {ArrayBuffer|ArrayBufferView|Blob} data - Incoming binary data
+   * @returns {Promise<Uint8Array>} View of the provided binary data
+   */
+  async toUint8Array(data) {
+    if (data instanceof ArrayBuffer) {
+      return new Uint8Array(data);
+    }
+
+    if (ArrayBuffer.isView(data)) {
+      return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+    }
+
+    if (typeof Blob !== "undefined" && data instanceof Blob) {
+      const buffer = await data.arrayBuffer();
+      return new Uint8Array(buffer);
+    }
+
+    throw new Error("Unsupported binary data type");
   }
 
   onClose() {
@@ -249,6 +583,11 @@ const wsx = createHonoWSXServer();`,
   }
 
   handleMessage(message) {
+    if (message && typeof message === "object" && message.type === "json") {
+      this.dispatchJson(message);
+      return;
+    }
+
     // Handle main response
     this.processSwapUpdate(
       {
@@ -805,15 +1144,29 @@ const wsx = createHonoWSXServer();`,
   }
 
   send(message) {
+    const isJsonMessage =
+      message && typeof message === "object" && message.type === "json";
+
     if (this.demoMode) {
+      if (isJsonMessage) {
+        this.log("Cannot send JSON message: demo mode active");
+        return;
+      }
+
       // Handle demo mode with simulated responses
       setTimeout(() => {
         const demoResponse = this.generateDemoResponse(message);
         this.handleMessage(demoResponse);
       }, 100 + Math.random() * 300); // Simulate network delay
-    } else if (this.ws && this.isConnected) {
+      return;
+    }
+
+    if (this.ws && this.isConnected) {
       this.ws.send(JSON.stringify(message));
-      this.log("Sent message:", message);
+      this.log(
+        isJsonMessage ? "Sent JSON message:" : "Sent message:",
+        message
+      );
     } else {
       this.log("Cannot send message: not connected");
     }

--- a/packages/client/wsx.js
+++ b/packages/client/wsx.js
@@ -30,6 +30,35 @@
  * @property {HTMLElement} [element] - Source element
  */
 
+/**
+ * @typedef {Object} WSXStreamOptions
+ * @property {string} [id] - Optional stream identifier
+ * @property {Object} [metadata] - Additional metadata to include with the stream
+ */
+
+/**
+ * @typedef {Object} WSXJSONOptions
+ * @property {string} [id] - Optional JSON message identifier
+ * @property {Object} [metadata] - Additional metadata to include with the message
+ */
+
+/**
+ * @typedef {Object} WSXJSONDetail
+ * @property {string} id - Message identifier
+ * @property {string} channel - Channel the JSON message was published to
+ * @property {Object} metadata - Optional metadata provided by the sender
+ * @property {*} data - The JSON payload
+ */
+
+/**
+ * @typedef {Object} WSXStreamDetail
+ * @property {string} id - Stream identifier
+ * @property {string} channel - Logical channel for the stream
+ * @property {Object} metadata - Metadata provided by the sender
+ * @property {Uint8Array} data - Raw binary payload
+ * @property {ArrayBuffer} arrayBuffer - Copy of the payload as an ArrayBuffer
+ */
+
 class WSX {
   /**
    * @param {WSXConfig} config - Configuration object
@@ -42,6 +71,10 @@ class WSX {
     this.requestCounter = 0;
     this.throttleTimers = new Map();
     this.debounceTimers = new Map();
+    this.streamHandlers = new Map();
+    this.jsonHandlers = new Map();
+    this.textEncoder = new TextEncoder();
+    this.textDecoder = new TextDecoder();
 
     this.config = {
       reconnectInterval: 3000,
@@ -57,6 +90,7 @@ class WSX {
   connect() {
     try {
       this.ws = new WebSocket(this.config.url);
+      this.ws.binaryType = "arraybuffer";
       this.ws.onopen = this.onOpen.bind(this);
       this.ws.onmessage = this.onMessage.bind(this);
       this.ws.onclose = this.onClose.bind(this);
@@ -76,13 +110,313 @@ class WSX {
     document.dispatchEvent(new CustomEvent("wsx:connected"));
   }
 
-  onMessage(event) {
+  async onMessage(event) {
     try {
-      const message = JSON.parse(event.data);
-      this.handleMessage(message);
+      if (typeof event.data === "string") {
+        const message = JSON.parse(event.data);
+        this.handleMessage(message);
+      } else {
+        await this.handleBinaryMessage(event.data);
+      }
     } catch (error) {
-      this.log("Error parsing message:", error);
+      this.log("Error processing message:", error);
     }
+  }
+
+  async handleBinaryMessage(data) {
+    try {
+      const bytes = await this.toUint8Array(data);
+
+      if (bytes.byteLength < 4) {
+        throw new Error("Stream message too small");
+      }
+
+      const view = new DataView(
+        bytes.buffer,
+        bytes.byteOffset,
+        bytes.byteLength
+      );
+      const headerLength = view.getUint32(0, false);
+      const headerStart = 4;
+      const headerEnd = headerStart + headerLength;
+
+      if (bytes.byteLength < headerEnd) {
+        throw new Error("Stream message header incomplete");
+      }
+
+      const headerBytes = bytes.subarray(headerStart, headerEnd);
+      const headerString = this.textDecoder.decode(headerBytes);
+      const header = JSON.parse(headerString);
+
+      if (!header || header.type !== "stream") {
+        this.log("Unsupported binary message received", header);
+        return;
+      }
+
+      if (typeof header.id !== "string" || typeof header.channel !== "string") {
+        throw new Error("Invalid stream header");
+      }
+
+      const payload = bytes.subarray(headerEnd);
+
+      this.dispatchStream(
+        {
+          id: header.id,
+          channel: header.channel,
+          metadata: header.metadata || {},
+        },
+        payload
+      );
+    } catch (error) {
+      this.log("Error handling binary message:", error);
+    }
+  }
+
+  /**
+   * Dispatch an incoming JSON message to registered handlers and DOM listeners.
+   * @param {{id?: string, channel: string, metadata?: Object, data: any, type?: string}} message
+   */
+  dispatchJson(message) {
+    if (!message || typeof message.channel !== "string") {
+      this.log("Invalid JSON message received", message);
+      return;
+    }
+
+    const detail = {
+      id:
+        typeof message.id === "string"
+          ? message.id
+          : this.generateJsonId(),
+      channel: message.channel,
+      metadata:
+        message.metadata && typeof message.metadata === "object"
+          ? message.metadata
+          : {},
+      data: message.data,
+    };
+
+    const handler =
+      this.jsonHandlers.get(detail.channel) || this.jsonHandlers.get("");
+
+    if (handler) {
+      try {
+        handler(detail);
+      } catch (error) {
+        this.log("Error in JSON handler:", error);
+      }
+    }
+
+    document.dispatchEvent(new CustomEvent("wsx:json", { detail }));
+  }
+
+  /**
+   * Dispatch a decoded stream payload to registered handlers and DOM listeners.
+   * @param {{id: string, channel: string, metadata: Object}} message - Stream metadata
+   * @param {Uint8Array} payload - Binary payload for the stream message
+   */
+  dispatchStream(message, payload) {
+    const detail = {
+      id: message.id,
+      channel: message.channel,
+      metadata: message.metadata || {},
+      data: payload,
+      arrayBuffer: payload.buffer.slice(
+        payload.byteOffset,
+        payload.byteOffset + payload.byteLength
+      ),
+    };
+
+    const handler =
+      this.streamHandlers.get(message.channel) ||
+      this.streamHandlers.get("");
+
+    if (handler) {
+      try {
+        handler(detail);
+      } catch (error) {
+        this.log("Error in stream handler:", error);
+      }
+    }
+
+    document.dispatchEvent(new CustomEvent("wsx:stream", { detail }));
+  }
+
+  /**
+   * Register a handler for incoming stream data.
+   * @param {string|function} channelOrHandler - Channel name or catch-all handler
+   * @param {function} [handler] - Handler invoked when the specified channel receives data
+   * @returns {WSX} The WSX instance for chaining
+   */
+  onJson(channelOrHandler, handler) {
+    if (typeof channelOrHandler === "string") {
+      if (typeof handler !== "function") {
+        throw new Error("JSON handler must be a function");
+      }
+      this.jsonHandlers.set(channelOrHandler, handler);
+    } else if (typeof channelOrHandler === "function") {
+      this.jsonHandlers.set("", channelOrHandler);
+    } else {
+      throw new Error("Invalid JSON handler registration");
+    }
+
+    return this;
+  }
+
+  /**
+   * Remove a previously registered JSON handler.
+   * @param {string} [channel] - Channel to remove; omitting clears all handlers
+   * @returns {WSX} The WSX instance for chaining
+   */
+  offJson(channel) {
+    if (typeof channel === "string") {
+      this.jsonHandlers.delete(channel);
+    } else {
+      this.jsonHandlers.clear();
+    }
+
+    return this;
+  }
+
+  /**
+   * Register a handler for incoming stream data.
+   * @param {string|function} channelOrHandler - Channel name or catch-all handler
+   * @param {function} [handler] - Handler invoked when the specified channel receives data
+   * @returns {WSX} The WSX instance for chaining
+   */
+  onStream(channelOrHandler, handler) {
+    if (typeof channelOrHandler === "string") {
+      if (typeof handler !== "function") {
+        throw new Error("Stream handler must be a function");
+      }
+      this.streamHandlers.set(channelOrHandler, handler);
+    } else if (typeof channelOrHandler === "function") {
+      this.streamHandlers.set("", channelOrHandler);
+    } else {
+      throw new Error("Invalid stream handler registration");
+    }
+
+    return this;
+  }
+
+  /**
+   * Remove a previously registered stream handler.
+   * @param {string} [channel] - Channel to remove; omitting clears all handlers
+   * @returns {WSX} The WSX instance for chaining
+   */
+  offStream(channel) {
+    if (typeof channel === "string") {
+      this.streamHandlers.delete(channel);
+    } else {
+      this.streamHandlers.clear();
+    }
+
+    return this;
+  }
+
+  generateStreamId() {
+    return `stream_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+  }
+
+  generateJsonId() {
+    return `json_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+  }
+
+  /**
+   * Send a binary stream payload to the server.
+   * @param {string} channel - Logical channel name used by server handlers
+   * @param {ArrayBuffer|ArrayBufferView|Blob} data - Binary payload to transmit
+   * @param {WSXStreamOptions} [options] - Additional stream options
+   * @returns {Promise<string>} Resolves with the stream identifier
+   */
+  async sendStream(channel, data, options = {}) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new Error("Cannot send stream: connection is not open");
+    }
+
+    const streamId = options.id || this.generateStreamId();
+    const header = {
+      type: "stream",
+      id: streamId,
+      channel,
+    };
+
+    if (options.metadata !== undefined) {
+      header.metadata = options.metadata;
+    }
+
+    const headerBytes = this.textEncoder.encode(JSON.stringify(header));
+    const headerLengthBuffer = new ArrayBuffer(4);
+    new DataView(headerLengthBuffer).setUint32(
+      0,
+      headerBytes.byteLength,
+      false
+    );
+    const headerLengthBytes = new Uint8Array(headerLengthBuffer);
+    const payloadBytes = await this.toUint8Array(data);
+    const frame = new Uint8Array(
+      4 + headerBytes.byteLength + payloadBytes.byteLength
+    );
+    frame.set(headerLengthBytes, 0);
+    frame.set(headerBytes, 4);
+    frame.set(payloadBytes, 4 + headerBytes.byteLength);
+
+    this.ws.send(frame);
+
+    return streamId;
+  }
+
+  /**
+   * Send a JSON message payload to the server.
+   * @param {string} channel - Logical channel name used by server handlers
+   * @param {*} data - JSON-serializable payload to transmit
+   * @param {WSXJSONOptions} [options] - Additional message options
+   * @returns {string} Identifier of the sent JSON message
+   */
+  sendJson(channel, data, options = {}) {
+    if (this.demoMode) {
+      throw new Error("Cannot send JSON messages while demo mode is active");
+    }
+
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new Error("Cannot send JSON message: connection is not open");
+    }
+
+    const message = {
+      type: "json",
+      id: options.id || this.generateJsonId(),
+      channel,
+      data,
+    };
+
+    if (options.metadata !== undefined) {
+      message.metadata = options.metadata;
+    }
+
+    this.send(message);
+
+    return message.id;
+  }
+
+  /**
+   * Normalise a variety of binary inputs into a Uint8Array view.
+   * @param {ArrayBuffer|ArrayBufferView|Blob} data - Incoming binary data
+   * @returns {Promise<Uint8Array>} View of the provided binary data
+   */
+  async toUint8Array(data) {
+    if (data instanceof ArrayBuffer) {
+      return new Uint8Array(data);
+    }
+
+    if (ArrayBuffer.isView(data)) {
+      return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+    }
+
+    if (typeof Blob !== "undefined" && data instanceof Blob) {
+      const buffer = await data.arrayBuffer();
+      return new Uint8Array(buffer);
+    }
+
+    throw new Error("Unsupported binary data type");
   }
 
   onClose() {
@@ -249,6 +583,11 @@ const wsx = createHonoWSXServer();`,
   }
 
   handleMessage(message) {
+    if (message && typeof message === "object" && message.type === "json") {
+      this.dispatchJson(message);
+      return;
+    }
+
     // Handle main response
     this.processSwapUpdate(
       {
@@ -805,15 +1144,29 @@ const wsx = createHonoWSXServer();`,
   }
 
   send(message) {
+    const isJsonMessage =
+      message && typeof message === "object" && message.type === "json";
+
     if (this.demoMode) {
+      if (isJsonMessage) {
+        this.log("Cannot send JSON message: demo mode active");
+        return;
+      }
+
       // Handle demo mode with simulated responses
       setTimeout(() => {
         const demoResponse = this.generateDemoResponse(message);
         this.handleMessage(demoResponse);
       }, 100 + Math.random() * 300); // Simulate network delay
-    } else if (this.ws && this.isConnected) {
+      return;
+    }
+
+    if (this.ws && this.isConnected) {
       this.ws.send(JSON.stringify(message));
-      this.log("Sent message:", message);
+      this.log(
+        isJsonMessage ? "Sent JSON message:" : "Sent message:",
+        message
+      );
     } else {
       this.log("Cannot send message: not connected");
     }

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -9,6 +9,13 @@ export type {
   WSXHandler,
   WSXServerAdapter,
   WSXServerConfig,
+  WSXBinaryData,
+  WSXJSONMessage,
+  WSXJSONHandler,
+  WSXJSONSendOptions,
+  WSXStreamHandler,
+  WSXStreamMessage,
+  WSXStreamSendOptions,
 } from "./types";
 
 // Convenience function to create a WSX server with an adapter

--- a/packages/core/types.ts
+++ b/packages/core/types.ts
@@ -24,7 +24,7 @@ export interface WSXOOBUpdate {
 export interface WSXConnection {
   id: string;
   sessionData?: Record<string, any>;
-  send(data: string): void;
+  send(data: string | WSXBinaryData): void;
   close(): void;
 }
 
@@ -33,10 +33,46 @@ export type WSXHandler = (
   connection: WSXConnection
 ) => Promise<WSXResponse | WSXResponse[] | void>;
 
+export type WSXBinaryData = ArrayBuffer | ArrayBufferView;
+
+export interface WSXJSONMessage {
+  id: string;
+  channel: string;
+  data: any;
+  metadata?: Record<string, any>;
+}
+
+export type WSXJSONHandler = (
+  message: WSXJSONMessage,
+  connection: WSXConnection
+) => Promise<void> | void;
+
+export interface WSXJSONSendOptions {
+  id?: string;
+  metadata?: Record<string, any>;
+}
+
+export interface WSXStreamMessage {
+  id: string;
+  channel: string;
+  metadata?: Record<string, any>;
+}
+
+export type WSXStreamHandler = (
+  message: WSXStreamMessage,
+  data: Uint8Array,
+  connection: WSXConnection
+) => Promise<void> | void;
+
+export interface WSXStreamSendOptions {
+  id?: string;
+  metadata?: Record<string, any>;
+}
+
 export interface WSXServerAdapter {
   setupWebSocket(
     path: string,
-    onMessage: (data: string, connection: WSXConnection) => void
+    onMessage: (data: string | WSXBinaryData, connection: WSXConnection) => void
   ): void;
   onConnection?(connection: WSXConnection): void;
   onDisconnection?(connection: WSXConnection): void;

--- a/packages/core/wsx-server.ts
+++ b/packages/core/wsx-server.ts
@@ -1,11 +1,40 @@
-import { WSXRequest, WSXResponse, WSXConnection, WSXHandler, WSXServerAdapter, WSXServerConfig } from './types.js';
+import {
+  WSXRequest,
+  WSXResponse,
+  WSXConnection,
+  WSXHandler,
+  WSXServerAdapter,
+  WSXServerConfig,
+  WSXBinaryData,
+  WSXJSONHandler,
+  WSXJSONMessage,
+  WSXJSONSendOptions,
+  WSXStreamHandler,
+  WSXStreamMessage,
+  WSXStreamSendOptions,
+} from './types.js';
+
+const STREAM_MESSAGE_TYPE = 'stream';
+const JSON_MESSAGE_TYPE = 'json';
+
+type WSXJSONEnvelope = {
+  type: string;
+  id?: string;
+  channel: string;
+  data: any;
+  metadata?: Record<string, any>;
+};
 
 export class WSXServer {
   private connections = new Map<string, WSXConnection>();
   private handlers = new Map<string, WSXHandler>();
+  private jsonHandlers = new Map<string, WSXJSONHandler>();
+  private streamHandlers = new Map<string, WSXStreamHandler>();
   private connectionCounter = 0;
   private adapter: WSXServerAdapter;
   private config: WSXServerConfig;
+  private textEncoder = new TextEncoder();
+  private textDecoder = new TextDecoder();
 
   constructor(adapter: WSXServerAdapter, config?: WSXServerConfig) {
     this.adapter = adapter;
@@ -15,31 +44,93 @@ export class WSXServer {
 
   private setupWebSocket() {
     const websocketPath = this.config.websocketPath || '/ws';
-    this.adapter.setupWebSocket(websocketPath, async (data: string, connection: WSXConnection) => {
-      try {
-        const request: WSXRequest = JSON.parse(data);
-        console.log('Received message:', request);
+    this.adapter.setupWebSocket(
+      websocketPath,
+      async (data: string | WSXBinaryData, connection: WSXConnection) => {
+        this.registerConnection(connection);
 
-        // Register connection if not already registered
-        if (!this.connections.has(connection.id)) {
-          this.connections.set(connection.id, connection);
-          console.log(`WSX connection registered: ${connection.id}`);
-          
-          // Call config callback first, then adapter callback
-          if (this.config.onConnection) {
-            this.config.onConnection(connection);
+        try {
+          if (typeof data === 'string') {
+            await this.handleTextMessage(data, connection);
+          } else if (this.isBinaryData(data)) {
+            await this.handleBinaryMessage(data, connection);
+          } else {
+            console.warn(
+              `Unsupported WSX message type received: ${typeof data}`
+            );
           }
-          
-          if (this.adapter.onConnection) {
-            this.adapter.onConnection(connection);
-          }
+        } catch (error) {
+          console.error('Error handling WSX message:', error);
         }
-
-        await this.handleRequest(request, connection);
-      } catch (error) {
-        console.error('Error handling WSX message:', error);
       }
-    });
+    );
+  }
+
+  private async handleTextMessage(data: string, connection: WSXConnection) {
+    const payload = JSON.parse(data);
+
+    if (this.isJsonEnvelope(payload)) {
+      const message = this.normalizeJsonEnvelope(payload);
+      console.log(
+        `Received JSON message on channel ${message.channel} (${message.id})`
+      );
+      await this.handleJson(message, connection);
+      return;
+    }
+
+    const request: WSXRequest = payload;
+    console.log('Received message:', request);
+    await this.handleRequest(request, connection);
+  }
+
+  private async handleBinaryMessage(
+    data: WSXBinaryData,
+    connection: WSXConnection
+  ) {
+    const { message, payload } = this.decodeStreamMessage(data);
+    console.log(
+      `Received stream message on channel ${message.channel} (${message.id})`
+    );
+    await this.handleStream(message, payload, connection);
+  }
+
+  private isJsonEnvelope(value: unknown): value is WSXJSONEnvelope {
+    return (
+      value !== null &&
+      typeof value === 'object' &&
+      (value as WSXJSONEnvelope).type === JSON_MESSAGE_TYPE &&
+      typeof (value as WSXJSONEnvelope).channel === 'string' &&
+      'data' in (value as Record<string, unknown>)
+    );
+  }
+
+  private normalizeJsonEnvelope(envelope: WSXJSONEnvelope): WSXJSONMessage {
+    return {
+      id:
+        typeof envelope.id === 'string'
+          ? envelope.id
+          : this.generateJsonId(),
+      channel: envelope.channel,
+      data: envelope.data,
+      metadata: envelope.metadata,
+    };
+  }
+
+  private registerConnection(connection: WSXConnection) {
+    if (this.connections.has(connection.id)) {
+      return;
+    }
+
+    this.connections.set(connection.id, connection);
+    console.log(`WSX connection registered: ${connection.id}`);
+
+    if (this.config.onConnection) {
+      this.config.onConnection(connection);
+    }
+
+    if (this.adapter.onConnection) {
+      this.adapter.onConnection(connection);
+    }
   }
 
   private async handleRequest(request: WSXRequest, connection: WSXConnection) {
@@ -58,6 +149,46 @@ export class WSXServer {
     }
 
     console.warn(`No handler found for: ${request.handler || 'default'}`);
+  }
+
+  private async handleStream(
+    message: WSXStreamMessage,
+    payload: Uint8Array,
+    connection: WSXConnection
+  ) {
+    const handler =
+      this.streamHandlers.get(message.channel) ??
+      this.streamHandlers.get('');
+
+    if (!handler) {
+      console.warn(`No stream handler found for channel: ${message.channel}`);
+      return;
+    }
+
+    try {
+      await handler(message, payload, connection);
+    } catch (error) {
+      console.error(`Error in stream handler for ${message.channel}:`, error);
+    }
+  }
+
+  private async handleJson(
+    message: WSXJSONMessage,
+    connection: WSXConnection
+  ) {
+    const handler =
+      this.jsonHandlers.get(message.channel) ?? this.jsonHandlers.get('');
+
+    if (!handler) {
+      console.warn(`No JSON handler found for channel: ${message.channel}`);
+      return;
+    }
+
+    try {
+      await handler(message, connection);
+    } catch (error) {
+      console.error(`Error in JSON handler for ${message.channel}:`, error);
+    }
   }
 
   private async executeHandler(
@@ -104,6 +235,164 @@ export class WSXServer {
     }
   }
 
+  private sendJsonMessage(
+    connection: WSXConnection,
+    message: WSXJSONMessage
+  ) {
+    try {
+      connection.send(this.encodeJsonMessage(message));
+    } catch (error) {
+      console.error(
+        `Error sending JSON message for ${message.channel}:`,
+        error
+      );
+    }
+  }
+
+  private sendStreamFrame(
+    connection: WSXConnection,
+    message: WSXStreamMessage,
+    payload: WSXBinaryData
+  ) {
+    try {
+      const frame = this.encodeStreamMessage(message, payload);
+      connection.send(frame);
+    } catch (error) {
+      console.error(
+        `Error sending stream message for ${message.channel}:`,
+        error
+      );
+    }
+  }
+
+  private createJsonMessage(
+    channel: string,
+    data: any,
+    options?: WSXJSONSendOptions
+  ): WSXJSONMessage {
+    return {
+      id: options?.id || this.generateJsonId(),
+      channel,
+      data,
+      metadata: options?.metadata,
+    };
+  }
+
+  private createStreamMessage(
+    channel: string,
+    options?: WSXStreamSendOptions
+  ): WSXStreamMessage {
+    return {
+      id: options?.id || this.generateStreamId(),
+      channel,
+      metadata: options?.metadata,
+    };
+  }
+
+  private encodeStreamMessage(
+    message: WSXStreamMessage,
+    payload: WSXBinaryData
+  ): Uint8Array {
+    const headerObject: Record<string, any> = {
+      type: STREAM_MESSAGE_TYPE,
+      id: message.id,
+      channel: message.channel,
+    };
+
+    if (message.metadata !== undefined) {
+      headerObject.metadata = message.metadata;
+    }
+
+    const headerBytes = this.textEncoder.encode(JSON.stringify(headerObject));
+    const payloadBytes = this.toUint8Array(payload);
+    const buffer = new ArrayBuffer(4 + headerBytes.byteLength + payloadBytes.byteLength);
+    const view = new DataView(buffer);
+    view.setUint32(0, headerBytes.byteLength, false);
+
+    const frame = new Uint8Array(buffer);
+    frame.set(headerBytes, 4);
+    frame.set(payloadBytes, 4 + headerBytes.byteLength);
+
+    return frame;
+  }
+
+  private encodeJsonMessage(message: WSXJSONMessage): string {
+    const envelope: Record<string, any> = {
+      type: JSON_MESSAGE_TYPE,
+      id: message.id,
+      channel: message.channel,
+      data: message.data,
+    };
+
+    if (message.metadata !== undefined) {
+      envelope.metadata = message.metadata;
+    }
+
+    return JSON.stringify(envelope);
+  }
+
+  private decodeStreamMessage(
+    data: WSXBinaryData
+  ): { message: WSXStreamMessage; payload: Uint8Array } {
+    const bytes = this.toUint8Array(data);
+
+    if (bytes.byteLength < 4) {
+      throw new Error('Stream message is too short to contain header length');
+    }
+
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    const headerLength = view.getUint32(0, false);
+    const headerStart = 4;
+    const headerEnd = headerStart + headerLength;
+
+    if (bytes.byteLength < headerEnd) {
+      throw new Error('Stream message header is incomplete');
+    }
+
+    const headerBytes = bytes.subarray(headerStart, headerEnd);
+    const headerString = this.textDecoder.decode(headerBytes);
+    const header = JSON.parse(headerString);
+
+    if (!header || header.type !== STREAM_MESSAGE_TYPE) {
+      throw new Error('Unsupported binary message received');
+    }
+
+    if (typeof header.id !== 'string' || typeof header.channel !== 'string') {
+      throw new Error('Invalid stream message header');
+    }
+
+    const payload = bytes.subarray(headerEnd);
+
+    return {
+      message: {
+        id: header.id,
+        channel: header.channel,
+        metadata: header.metadata,
+      },
+      payload,
+    };
+  }
+
+  private toUint8Array(data: WSXBinaryData): Uint8Array {
+    if (data instanceof ArrayBuffer) {
+      return new Uint8Array(data);
+    }
+
+    return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  }
+
+  private isBinaryData(data: unknown): data is WSXBinaryData {
+    return data instanceof ArrayBuffer || ArrayBuffer.isView(data as any);
+  }
+
+  private generateStreamId(): string {
+    return `stream_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+  }
+
+  private generateJsonId(): string {
+    return `json_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+  }
+
   // Public API
   public on(handler: string, handlerFunction: WSXHandler): this;
   public on(handlerFunction: WSXHandler): this;
@@ -121,6 +410,50 @@ export class WSXServer {
     return this;
   }
 
+  public onJson(handler: string, handlerFunction: WSXJSONHandler): this;
+  public onJson(handlerFunction: WSXJSONHandler): this;
+  public onJson(
+    handlerOrFunction: string | WSXJSONHandler,
+    handlerFunction?: WSXJSONHandler
+  ): this {
+    if (typeof handlerOrFunction === 'string') {
+      this.jsonHandlers.set(handlerOrFunction, handlerFunction!);
+    } else {
+      this.jsonHandlers.set('', handlerOrFunction);
+    }
+
+    return this;
+  }
+
+  public onStream(handler: string, handlerFunction: WSXStreamHandler): this;
+  public onStream(handlerFunction: WSXStreamHandler): this;
+  public onStream(
+    handlerOrFunction: string | WSXStreamHandler,
+    handlerFunction?: WSXStreamHandler
+  ): this {
+    if (typeof handlerOrFunction === 'string') {
+      this.streamHandlers.set(handlerOrFunction, handlerFunction!);
+    } else {
+      this.streamHandlers.set('', handlerOrFunction);
+    }
+
+    return this;
+  }
+
+  public broadcastJson(
+    channel: string,
+    data: any,
+    options?: WSXJSONSendOptions
+  ): string {
+    const message = this.createJsonMessage(channel, data, options);
+
+    for (const connection of this.connections.values()) {
+      this.sendJsonMessage(connection, message);
+    }
+
+    return message.id;
+  }
+
   public broadcast(target: string, html: string, swap?: string) {
     const response: WSXResponse = {
       id: `broadcast_${Date.now()}`,
@@ -132,6 +465,20 @@ export class WSXServer {
     for (const connection of this.connections.values()) {
       this.sendResponse(response, connection);
     }
+  }
+
+  public broadcastStream(
+    channel: string,
+    payload: WSXBinaryData,
+    options?: WSXStreamSendOptions
+  ): string {
+    const message = this.createStreamMessage(channel, options);
+
+    for (const connection of this.connections.values()) {
+      this.sendStreamFrame(connection, message, payload);
+    }
+
+    return message.id;
   }
 
   public sendToConnection(
@@ -153,6 +500,38 @@ export class WSXServer {
     }
   }
 
+  public sendStreamToConnection(
+    connectionId: string,
+    channel: string,
+    payload: WSXBinaryData,
+    options?: WSXStreamSendOptions
+  ): string | undefined {
+    const connection = this.connections.get(connectionId);
+    if (!connection) {
+      return undefined;
+    }
+
+    const message = this.createStreamMessage(channel, options);
+    this.sendStreamFrame(connection, message, payload);
+    return message.id;
+  }
+
+  public sendJsonToConnection(
+    connectionId: string,
+    channel: string,
+    data: any,
+    options?: WSXJSONSendOptions
+  ): string | undefined {
+    const connection = this.connections.get(connectionId);
+    if (!connection) {
+      return undefined;
+    }
+
+    const message = this.createJsonMessage(channel, data, options);
+    this.sendJsonMessage(connection, message);
+    return message.id;
+  }
+
   public getApp() {
     return this.adapter.getApp();
   }
@@ -169,12 +548,12 @@ export class WSXServer {
     const connection = this.connections.get(connectionId);
     if (connection) {
       this.connections.delete(connectionId);
-      
+
       // Call config callback first, then adapter callback
       if (this.config.onDisconnection) {
         this.config.onDisconnection(connection);
       }
-      
+
       if (this.adapter.onDisconnection) {
         this.adapter.onDisconnection(connection);
       }

--- a/packages/express/index.ts
+++ b/packages/express/index.ts
@@ -6,6 +6,7 @@ import {
   WSXServerAdapter,
   WSXConnection,
   WSXServerConfig,
+  WSXBinaryData,
 } from "../core";
 
 export class ExpressAdapter implements WSXServerAdapter {
@@ -20,7 +21,7 @@ export class ExpressAdapter implements WSXServerAdapter {
 
   setupWebSocket(
     path: string,
-    onMessage: (data: string, connection: WSXConnection) => void
+    onMessage: (data: string | WSXBinaryData, connection: WSXConnection) => void
   ): void {
     // Create WebSocket server
     this.wss = new WebSocketServer({ noServer: true });
@@ -32,10 +33,18 @@ export class ExpressAdapter implements WSXServerAdapter {
       const connection: WSXConnection = {
         id: connectionId,
         sessionData: {},
-        send: (data: string) => {
+        send: (data: string | WSXBinaryData) => {
           try {
             if (ws.readyState === WebSocket.OPEN) {
-              ws.send(data);
+              if (typeof data === "string") {
+                ws.send(data);
+              } else if (data instanceof ArrayBuffer) {
+                ws.send(data);
+              } else if (ArrayBuffer.isView(data)) {
+                ws.send(data);
+              } else {
+                ws.send(data as any);
+              }
             }
           } catch (error) {
             console.error("Error sending data:", error);
@@ -50,8 +59,26 @@ export class ExpressAdapter implements WSXServerAdapter {
         },
       };
 
-      ws.on("message", async (data) => {
-        await onMessage(data.toString(), connection);
+      ws.on("message", async (data, isBinary) => {
+        let payload: string | WSXBinaryData;
+
+        if (isBinary) {
+          if (Array.isArray(data)) {
+            payload = Buffer.concat(data);
+          } else {
+            payload = data as WSXBinaryData;
+          }
+        } else {
+          if (typeof data === "string") {
+            payload = data;
+          } else if (Array.isArray(data)) {
+            payload = Buffer.concat(data).toString();
+          } else {
+            payload = (data as Buffer).toString();
+          }
+        }
+
+        await onMessage(payload, connection);
       });
 
       ws.on("close", () => {

--- a/packages/hono/index.ts
+++ b/packages/hono/index.ts
@@ -5,6 +5,7 @@ import {
   WSXServerAdapter,
   WSXConnection,
   WSXServerConfig,
+  WSXBinaryData,
 } from "../core";
 
 export class HonoAdapter implements WSXServerAdapter {
@@ -18,7 +19,7 @@ export class HonoAdapter implements WSXServerAdapter {
 
   setupWebSocket(
     path: string,
-    onMessage: (data: string, connection: WSXConnection) => void
+    onMessage: (data: string | WSXBinaryData, connection: WSXConnection) => void
   ): void {
     this.app.get(
       path,
@@ -34,9 +35,21 @@ export class HonoAdapter implements WSXServerAdapter {
           const connection: WSXConnection = {
             id: connectionId,
             sessionData: {},
-            send: (data: string) => {
+            send: (data: string | WSXBinaryData) => {
               try {
-                ws.send(data);
+                if (typeof data === "string") {
+                  ws.send(data);
+                } else {
+                  const view =
+                    data instanceof ArrayBuffer
+                      ? new Uint8Array(data)
+                      : new Uint8Array(
+                          data.buffer,
+                          data.byteOffset,
+                          data.byteLength
+                        );
+                  ws.send(view);
+                }
               } catch (error) {
                 console.error("Error sending data:", error);
               }
@@ -50,7 +63,20 @@ export class HonoAdapter implements WSXServerAdapter {
             },
           };
 
-          await onMessage(event.data.toString(), connection);
+          const rawData = event.data;
+          let payload: string | WSXBinaryData;
+
+          if (typeof rawData === "string") {
+            payload = rawData;
+          } else if (rawData instanceof ArrayBuffer) {
+            payload = rawData;
+          } else if (ArrayBuffer.isView(rawData)) {
+            payload = rawData as ArrayBufferView;
+          } else {
+            payload = String(rawData);
+          }
+
+          await onMessage(payload, connection);
         },
 
         onClose: (event, ws) => {


### PR DESCRIPTION
## Summary
- add JSON channel handling to the WSX server, including onJson registration plus helpers to broadcast or target structured payloads
- extend the browser client (and distributed bundles) with sendJson/onJson APIs and event dispatching for channel listeners
- document the new JSON channel workflow in the README so bidirectional structured messages are covered alongside streams

## Testing
- bun run build

------
https://chatgpt.com/codex/tasks/task_b_68d2c950ac68832a99a8769e9ff04df7